### PR TITLE
refactor: introduce LatestVersionResolver trait

### DIFF
--- a/src/version/mod.rs
+++ b/src/version/mod.rs
@@ -36,5 +36,7 @@ pub mod matcher;
 pub mod matchers;
 pub mod registries;
 pub mod registry;
+pub mod resolver;
+pub mod resolvers;
 pub mod semver;
 pub mod types;

--- a/src/version/resolver.rs
+++ b/src/version/resolver.rs
@@ -1,0 +1,85 @@
+//! Latest version resolver trait
+//!
+//! Provides registry-specific logic for determining the "latest" version
+//! from available versions and optional dist-tags.
+
+use std::collections::HashMap;
+
+use crate::version::resolvers::find_semantic_max;
+
+/// Trait for registry-specific latest version resolution logic
+///
+/// Each registry has different rules for determining the "latest" version:
+/// - Default: Semantic max version (used by Go, Crates.io, JSR)
+/// - GitHub Actions: Use published order (last item in the fetched list)
+/// - npm/pnpm: Use dist-tag "latest", fallback to semantic max
+pub trait LatestVersionResolver: Send + Sync {
+    /// Determine the "latest" version from available versions
+    ///
+    /// # Arguments
+    /// * `versions` - All available versions from the registry
+    /// * `dist_tags` - Optional dist-tags mapping (e.g., {"latest": "4.17.21"})
+    ///
+    /// # Returns
+    /// The resolved latest version, or None if no valid version found
+    ///
+    /// Default implementation returns the semantically maximum version.
+    /// Override this for registries that need different logic (e.g., npm with dist-tags).
+    fn resolve_latest(
+        &self,
+        versions: &[String],
+        _dist_tags: Option<&HashMap<String, String>>,
+    ) -> Option<String> {
+        find_semantic_max(versions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    /// Test resolver that uses default implementation
+    struct TestResolver;
+
+    impl LatestVersionResolver for TestResolver {
+        // Uses default implementation
+    }
+
+    #[test]
+    fn default_implementation_uses_find_semantic_max() {
+        let resolver = TestResolver;
+        let versions = vec![
+            "1.0.0".to_string(),
+            "2.0.0".to_string(),
+            "1.5.0".to_string(),
+        ];
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, None),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn default_implementation_ignores_dist_tags() {
+        let resolver = TestResolver;
+        let versions = vec!["1.0.0".to_string(), "2.0.0".to_string()];
+        let mut dist_tags = HashMap::new();
+        dist_tags.insert("latest".to_string(), "1.0.0".to_string());
+
+        // Default implementation ignores dist_tags and returns semantic max
+        assert_eq!(
+            resolver.resolve_latest(&versions, Some(&dist_tags)),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn default_implementation_returns_none_for_empty_versions() {
+        let resolver = TestResolver;
+        let versions: Vec<String> = vec![];
+
+        assert_eq!(resolver.resolve_latest(&versions, None), None);
+    }
+}

--- a/src/version/resolvers/crates.rs
+++ b/src/version/resolvers/crates.rs
@@ -1,0 +1,13 @@
+//! Crates.io latest version resolver
+
+use crate::version::resolver::LatestVersionResolver;
+
+/// Crates.io latest version resolver
+///
+/// Uses default implementation (semantic max version).
+/// Default behavior is tested in `src/version/resolver.rs`.
+pub struct CratesLatestResolver;
+
+impl LatestVersionResolver for CratesLatestResolver {
+    // Uses default implementation (semantic max)
+}

--- a/src/version/resolvers/github_actions.rs
+++ b/src/version/resolvers/github_actions.rs
@@ -1,0 +1,67 @@
+//! GitHub Actions latest version resolver
+
+use crate::version::resolver::LatestVersionResolver;
+
+/// GitHub Actions latest version resolver
+///
+/// Uses published order (last item) to match GitHub release ordering.
+pub struct GitHubActionsLatestResolver;
+
+impl LatestVersionResolver for GitHubActionsLatestResolver {
+    fn resolve_latest(
+        &self,
+        versions: &[String],
+        _dist_tags: Option<&std::collections::HashMap<String, String>>,
+    ) -> Option<String> {
+        versions.last().cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn returns_last_version_in_list() {
+        let resolver = GitHubActionsLatestResolver;
+        let versions = vec![
+            "v3.0.0".to_string(),
+            "v4.0.0".to_string(),
+            "v4.1.0".to_string(),
+        ];
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, None),
+            Some("v4.1.0".to_string())
+        );
+    }
+
+    #[test]
+    fn prefers_last_over_semantic_max() {
+        let resolver = GitHubActionsLatestResolver;
+        let versions = vec!["v2.0.0".to_string(), "v1.9.9".to_string()];
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, None),
+            Some("v1.9.9".to_string())
+        );
+    }
+
+    #[test]
+    fn supports_non_semver_tags() {
+        let resolver = GitHubActionsLatestResolver;
+        let versions = vec!["v4".to_string(), "v4-beta".to_string()];
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, None),
+            Some("v4-beta".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty_versions() {
+        let resolver = GitHubActionsLatestResolver;
+        let versions: Vec<String> = vec![];
+
+        assert_eq!(resolver.resolve_latest(&versions, None), None);
+    }
+}

--- a/src/version/resolvers/go.rs
+++ b/src/version/resolvers/go.rs
@@ -1,0 +1,13 @@
+//! Go latest version resolver
+
+use crate::version::resolver::LatestVersionResolver;
+
+/// Go latest version resolver
+///
+/// Uses default implementation (semantic max version).
+/// Default behavior is tested in `src/version/resolver.rs`.
+pub struct GoLatestResolver;
+
+impl LatestVersionResolver for GoLatestResolver {
+    // Uses default implementation (semantic max)
+}

--- a/src/version/resolvers/jsr.rs
+++ b/src/version/resolvers/jsr.rs
@@ -1,0 +1,13 @@
+//! JSR latest version resolver
+
+use crate::version::resolver::LatestVersionResolver;
+
+/// JSR latest version resolver
+///
+/// Uses default implementation (semantic max version).
+/// Default behavior is tested in `src/version/resolver.rs`.
+pub struct JsrLatestResolver;
+
+impl LatestVersionResolver for JsrLatestResolver {
+    // Uses default implementation (semantic max)
+}

--- a/src/version/resolvers/mod.rs
+++ b/src/version/resolvers/mod.rs
@@ -1,0 +1,56 @@
+//! Registry-specific latest version resolvers
+
+mod crates;
+mod github_actions;
+mod go;
+mod jsr;
+mod npm;
+mod pnpm;
+
+pub use crates::CratesLatestResolver;
+pub use github_actions::GitHubActionsLatestResolver;
+pub use go::GoLatestResolver;
+pub use jsr::JsrLatestResolver;
+pub use npm::NpmLatestResolver;
+pub use pnpm::PnpmCatalogLatestResolver;
+
+use semver::Version;
+
+/// Find the semantically maximum version from a list
+///
+/// Handles both `v`-prefixed (e.g., "v1.0.0") and non-prefixed versions.
+/// Invalid versions are skipped.
+pub fn find_semantic_max(versions: &[String]) -> Option<String> {
+    versions
+        .iter()
+        .filter_map(|v| {
+            let v_stripped = v.strip_prefix('v').unwrap_or(v);
+            Version::parse(v_stripped).ok().map(|parsed| (v, parsed))
+        })
+        .max_by(|(_, a), (_, b)| a.cmp(b))
+        .map(|(original, _)| original.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(vec![], None)]
+    #[case(vec!["v1.0.0", "v2.0.0", "v1.5.0"], Some("v2.0.0"))]
+    #[case(vec!["1.0.0", "2.0.0", "1.5.0"], Some("2.0.0"))]
+    #[case(vec!["v1.0.0", "2.0.0", "v1.5.0"], Some("2.0.0"))]
+    #[case(vec!["invalid", "v1.0.0", "not-semver"], Some("v1.0.0"))]
+    #[case(vec!["invalid", "not-semver"], None)]
+    fn find_semantic_max_returns_expected(
+        #[case] versions: Vec<&str>,
+        #[case] expected: Option<&str>,
+    ) {
+        let versions: Vec<String> = versions.into_iter().map(|s| s.to_string()).collect();
+        assert_eq!(
+            find_semantic_max(&versions),
+            expected.map(|s| s.to_string())
+        );
+    }
+}

--- a/src/version/resolvers/npm.rs
+++ b/src/version/resolvers/npm.rs
@@ -1,0 +1,90 @@
+//! npm latest version resolver
+
+use std::collections::HashMap;
+
+use crate::version::resolver::LatestVersionResolver;
+use crate::version::resolvers::find_semantic_max;
+
+/// npm latest version resolver
+///
+/// Prioritizes dist-tag "latest" over semantic max version.
+pub struct NpmLatestResolver;
+
+impl LatestVersionResolver for NpmLatestResolver {
+    fn resolve_latest(
+        &self,
+        versions: &[String],
+        dist_tags: Option<&HashMap<String, String>>,
+    ) -> Option<String> {
+        // Try dist-tag "latest" first
+        if let Some(tags) = dist_tags
+            && let Some(latest) = tags.get("latest")
+        {
+            return Some(latest.clone());
+        }
+
+        // Fallback to semantic max
+        find_semantic_max(versions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prioritizes_dist_tag_latest() {
+        let resolver = NpmLatestResolver;
+        let versions = vec![
+            "1.0.0".to_string(),
+            "2.0.0".to_string(),
+            "3.0.0".to_string(),
+        ];
+        let mut dist_tags = HashMap::new();
+        dist_tags.insert("latest".to_string(), "2.0.0".to_string());
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, Some(&dist_tags)),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_semantic_max_without_dist_tag() {
+        let resolver = NpmLatestResolver;
+        let versions = vec![
+            "1.0.0".to_string(),
+            "2.0.0".to_string(),
+            "1.5.0".to_string(),
+        ];
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, None),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_semantic_max_with_empty_dist_tags() {
+        let resolver = NpmLatestResolver;
+        let versions = vec![
+            "1.0.0".to_string(),
+            "2.0.0".to_string(),
+            "1.5.0".to_string(),
+        ];
+        let dist_tags = HashMap::new();
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, Some(&dist_tags)),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty_versions_and_no_dist_tag() {
+        let resolver = NpmLatestResolver;
+        let versions: Vec<String> = vec![];
+
+        assert_eq!(resolver.resolve_latest(&versions, None), None);
+    }
+}

--- a/src/version/resolvers/pnpm.rs
+++ b/src/version/resolvers/pnpm.rs
@@ -1,0 +1,91 @@
+//! pnpm catalog latest version resolver
+
+use std::collections::HashMap;
+
+use crate::version::resolver::LatestVersionResolver;
+use crate::version::resolvers::find_semantic_max;
+
+/// pnpm catalog latest version resolver
+///
+/// Prioritizes dist-tag "latest" over semantic max version.
+/// Uses the same logic as npm resolver.
+pub struct PnpmCatalogLatestResolver;
+
+impl LatestVersionResolver for PnpmCatalogLatestResolver {
+    fn resolve_latest(
+        &self,
+        versions: &[String],
+        dist_tags: Option<&HashMap<String, String>>,
+    ) -> Option<String> {
+        // Try dist-tag "latest" first
+        if let Some(tags) = dist_tags
+            && let Some(latest) = tags.get("latest")
+        {
+            return Some(latest.clone());
+        }
+
+        // Fallback to semantic max
+        find_semantic_max(versions)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prioritizes_dist_tag_latest() {
+        let resolver = PnpmCatalogLatestResolver;
+        let versions = vec![
+            "1.0.0".to_string(),
+            "2.0.0".to_string(),
+            "3.0.0".to_string(),
+        ];
+        let mut dist_tags = HashMap::new();
+        dist_tags.insert("latest".to_string(), "2.0.0".to_string());
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, Some(&dist_tags)),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_semantic_max_without_dist_tag() {
+        let resolver = PnpmCatalogLatestResolver;
+        let versions = vec![
+            "1.0.0".to_string(),
+            "2.0.0".to_string(),
+            "1.5.0".to_string(),
+        ];
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, None),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn falls_back_to_semantic_max_with_empty_dist_tags() {
+        let resolver = PnpmCatalogLatestResolver;
+        let versions = vec![
+            "1.0.0".to_string(),
+            "2.0.0".to_string(),
+            "1.5.0".to_string(),
+        ];
+        let dist_tags = HashMap::new();
+
+        assert_eq!(
+            resolver.resolve_latest(&versions, Some(&dist_tags)),
+            Some("2.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_for_empty_versions_and_no_dist_tag() {
+        let resolver = PnpmCatalogLatestResolver;
+        let versions: Vec<String> = vec![];
+
+        assert_eq!(resolver.resolve_latest(&versions, None), None);
+    }
+}

--- a/tests/helper/registry.rs
+++ b/tests/helper/registry.rs
@@ -22,6 +22,10 @@ use version_lsp::version::matchers::{
     NpmVersionMatcher, PnpmCatalogMatcher,
 };
 use version_lsp::version::registry::Registry;
+use version_lsp::version::resolvers::{
+    CratesLatestResolver, GitHubActionsLatestResolver, GoLatestResolver, JsrLatestResolver,
+    NpmLatestResolver, PnpmCatalogLatestResolver,
+};
 use version_lsp::version::types::PackageVersions;
 
 /// Mock registry for testing
@@ -74,31 +78,37 @@ pub fn create_test_resolver(
             Arc::new(GitHubActionsParser::new()),
             Arc::new(GitHubActionsMatcher),
             Arc::new(mock_registry),
+            Arc::new(GitHubActionsLatestResolver),
         ),
         RegistryType::Npm => PackageResolver::new(
             Arc::new(PackageJsonParser::new()),
             Arc::new(NpmVersionMatcher),
             Arc::new(mock_registry),
+            Arc::new(NpmLatestResolver),
         ),
         RegistryType::CratesIo => PackageResolver::new(
             Arc::new(CargoTomlParser::new()),
             Arc::new(CratesVersionMatcher),
             Arc::new(mock_registry),
+            Arc::new(CratesLatestResolver),
         ),
         RegistryType::GoProxy => PackageResolver::new(
             Arc::new(GoModParser::new()),
             Arc::new(GoVersionMatcher),
             Arc::new(mock_registry),
+            Arc::new(GoLatestResolver),
         ),
         RegistryType::PnpmCatalog => PackageResolver::new(
             Arc::new(PnpmWorkspaceParser),
             Arc::new(PnpmCatalogMatcher),
             Arc::new(mock_registry),
+            Arc::new(PnpmCatalogLatestResolver),
         ),
         RegistryType::Jsr => PackageResolver::new(
             Arc::new(DenoJsonParser::new()),
             Arc::new(JsrVersionMatcher),
             Arc::new(mock_registry),
+            Arc::new(JsrLatestResolver),
         ),
     }
 }


### PR DESCRIPTION
## Summary

- `LatestVersionResolver` トレイトを導入し、レジストリごとに最新バージョン決定ロジックを分離
- `Cache::get_latest_version` を削除し、責務を明確に分離
- デフォルト実装（semantic max）を提供し、コード重複を最小化

## Changes

### New Files
- `src/version/resolver.rs` - トレイト定義
- `src/version/resolvers/` - レジストリ別リゾルバー実装
  - `npm.rs`, `pnpm.rs`: dist-tag "latest" を優先
  - `github_actions.rs`: 公開順（リスト最後）を使用
  - `crates.rs`, `go.rs`, `jsr.rs`: デフォルト実装を使用

### Modified Files
- `compare_version`, `generate_diagnostics` にリゾルバーパラメータを追加
- `VersionStorer` から `get_latest_version` を削除、`get_all_dist_tags` を追加

## Test plan
- [x] 全490テスト通過
- [x] `cargo fmt --check` 通過
- [x] `cargo clippy -- -D warnings` 通過

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)