### PR TITLE
Add Docker Compose image tag version checking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ cargo test test_name
 # Run E2E tests for a specific registry
 cargo test --test e2e_npm
 cargo test --test e2e_crates
+cargo test --test e2e_docker
 
 # Generate coverage (requires cargo-llvm-cov)
 cargo llvm-cov nextest --lcov --output-path lcov.info
@@ -41,7 +42,7 @@ cargo clippy
 
 ## Architecture
 
-version-lsp is a Language Server Protocol implementation that checks package dependency versions across multiple registries (npm, crates.io, Go proxy, PyPI, GitHub Actions, JSR, pnpm catalogs).
+version-lsp is a Language Server Protocol implementation that checks package dependency versions across multiple registries (npm, crates.io, Go proxy, PyPI, GitHub Actions, JSR, pnpm catalogs, Docker Hub/ghcr.io).
 
 詳細なアーキテクチャ（データフロー図、DB スキーマ、各コンポーネントの責務など）は [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) を参照すること。実装・設計変更時は必ずこのドキュメントを確認し、整合性を保つこと。
 
@@ -63,7 +64,7 @@ File opened/changed in editor
 **Version layer** (`src/version/`): Three coordinated components:
 - `Registry` trait + `registries/`: Async HTTP fetchers for each package registry
 - `Cache` (`cache.rs`): SQLite storage with WAL mode, fetch deduplication, and refresh intervals
-- `VersionMatcher` trait + `matchers/`: Registry-specific comparison logic (semver ranges for npm/crates, partial version matching for GitHub Actions, PEP 508 for PyPI)
+- `VersionMatcher` trait + `matchers/`: Registry-specific comparison logic (semver ranges for npm/crates, partial version matching for GitHub Actions, PEP 508 for PyPI, suffix-aware Docker tag comparison)
 
 **LSP layer** (`src/lsp/`):
 - `Backend` is generic over `VersionStorer` trait (enables test injection)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A Language Server Protocol (LSP) implementation that provides version checking d
 | `pyproject.toml`                                      | PyPI            |
 | `.github/workflows/*.yaml`/`.github/actions/*/*.yaml` | GitHub Releases |
 | `deno.json` / `deno.jsonc`                            | JSR             |
+| `compose.yaml` / `docker-compose.yaml`                | Docker Hub / ghcr.io |
 
 ### pnpm Catalogs
 
@@ -55,6 +56,24 @@ catalogs:
   react18:
     react: ^18.2.0
 ```
+
+### Docker Compose
+
+Supports container image tag version checking in `compose.yaml` and `docker-compose.yaml` for Docker Hub and ghcr.io images:
+
+```yaml
+services:
+  web:
+    image: nginx:1.25          # Docker Hub official image
+  app:
+    image: myuser/myapp:v1.0.0 # Docker Hub user image
+  tools:
+    image: ghcr.io/owner/repo:v2.0.0 # GitHub Container Registry
+```
+
+- Suffix-aware comparison: `nginx:1.25-alpine` suggests `1.27-alpine` when available
+- Skips `latest` tags, digest references (`@sha256:...`), and variable expansions (`${VAR}`)
+- Unsupported registries (e.g., `mcr.microsoft.com`) are ignored
 
 ## Installation
 
@@ -137,6 +156,7 @@ lspconfig.version_lsp.setup({
         github = { enabled = true },
         pnpmCatalog = { enabled = true },
         jsr = { enabled = true },
+        docker = { enabled = true },
       },
       ignorePrerelease = true,  -- Ignore prerelease versions (default: true)
     },
@@ -156,6 +176,7 @@ lspconfig.version_lsp.setup({
 | `registries.github.enabled`      | boolean | `true`     | Enable GitHub Releases checks                              |
 | `registries.pnpmCatalog.enabled` | boolean | `true`     | Enable pnpm catalog checks                                 |
 | `registries.jsr.enabled`         | boolean | `true`     | Enable JSR registry checks                                 |
+| `registries.docker.enabled`      | boolean | `true`     | Enable Docker Hub / ghcr.io checks                         |
 | `ignorePrerelease`               | boolean | `true`     | Ignore prerelease versions (alpha, beta, rc, etc.)         |
 
 ## Data Storage

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -11,16 +11,16 @@ version-lsp is a Language Server Protocol (LSP) implementation that provides ver
 - Support for version range specifications in each ecosystem
 
 **Supported Registries:**
-| Registry        | File Format         | Version Specification                        |
-|-----------------|---------------------|----------------------------------------------|
-| npm             | package.json        | semver range (`^`, `~`, `>=`, `||`, etc.)    |
-| crates.io       | Cargo.toml          | Cargo requirements (`^`, `~`, `=`, `*`, etc.)|
-| Go Proxy        | go.mod              | Exact match                                  |
-| GitHub Releases | GitHub Actions YAML | Partial match (`v4` → `v4.x.x`)              |
-| PyPI            | pyproject.toml      | PEP 508 version specifiers                   |
-| JSR             | deno.json / deno.jsonc | semver range                              |
-| npm (pnpm)      | pnpm-workspace.yaml | semver range (catalog definitions)            |
-| Docker Hub / ghcr.io | compose.yaml / docker-compose.yaml | Suffix-aware tag comparison     |
+| Registry             | File Format                        | Version Specification                         |          |
+| -------------------- | ---------------------------------- | --------------------------------------------- | -------- |
+| npm                  | package.json                       | semver range (`^`, `~`, `>=`, `               | `, etc.) |
+| crates.io            | Cargo.toml                         | Cargo requirements (`^`, `~`, `=`, `*`, etc.) |          |
+| Go Proxy             | go.mod                             | Exact match                                   |          |
+| GitHub Releases      | GitHub Actions YAML                | Partial match (`v4` → `v4.x.x`)               |          |
+| PyPI                 | pyproject.toml                     | PEP 508 version specifiers                    |          |
+| JSR                  | deno.json / deno.jsonc             | semver range                                  |          |
+| npm (pnpm)           | pnpm-workspace.yaml                | semver range (catalog definitions)            |          |
+| Docker Hub / ghcr.io | compose.yaml / docker-compose.yaml | Suffix-aware tag comparison                   |          |
 
 ---
 
@@ -206,15 +206,15 @@ cache.get_packages_needing_refresh()
 Group by registry type
            │
            ▼
-┌──────────────────────────────────────────┐
-│   For each package (staggered 10ms):     │
-│     1. try_start_fetch() to acquire lock │
-│     2. registry.fetch_all_versions()     │
-│     3. Save versions + dist_tags to cache│
-│     4. finish_fetch() to release lock    │
-│                                          │
-│   ※ Continue processing even on errors   │
-└──────────────────────────────────────────┘
+┌───────────────────────────────────────────┐
+│   For each package (staggered 10ms):      │
+│     1. try_start_fetch() to acquire lock  │
+│     2. registry.fetch_all_versions()      │
+│     3. Save versions + dist_tags to cache │
+│     4. finish_fetch() to release lock     │
+│                                           │
+│   ※ Continue processing even on errors    │
+└───────────────────────────────────────────┘
 ```
 
 ### 3. Configuration Update Flow
@@ -329,16 +329,16 @@ pub trait VersionMatcher: Send + Sync {
 ```
 
 **Implementations:**
-| Matcher | Version Specification Example | Behavior |
-|---------|------------------------------|----------|
-| NpmMatcher | `^1.2.3`, `>=1.0.0 <2.0.0` | semver range evaluation |
-| CratesMatcher | `1.2.3`, `~1.2`, `>=1, <2` | Cargo requirements |
-| GoMatcher | `v1.2.3` | Exact match |
-| GitHubMatcher | `v4`, `v4.1` | Partial match (major/minor) |
-| PypiMatcher | `>=1.0,<2.0`, `~=1.4` | PEP 508 version specifiers |
-| JsrMatcher | `^1.2.3`, `~1.2.3` | semver range evaluation |
-| PnpmCatalogMatcher | `^1.2.3`, `~1.2.3` | semver range (same as npm) |
-| DockerMatcher | `1.25`, `1.25-alpine`, `v1.0.0` | Suffix-aware tag comparison, `resolve_latest` override |
+| Matcher            | Version Specification Example   | Behavior                                               |
+| ------------------ | ------------------------------- | ------------------------------------------------------ |
+| NpmMatcher         | `^1.2.3`, `>=1.0.0 <2.0.0`      | semver range evaluation                                |
+| CratesMatcher      | `1.2.3`, `~1.2`, `>=1, <2`      | Cargo requirements                                     |
+| GoMatcher          | `v1.2.3`                        | Exact match                                            |
+| GitHubMatcher      | `v4`, `v4.1`                    | Partial match (major/minor)                            |
+| PypiMatcher        | `>=1.0,<2.0`, `~=1.4`           | PEP 508 version specifiers                             |
+| JsrMatcher         | `^1.2.3`, `~1.2.3`              | semver range evaluation                                |
+| PnpmCatalogMatcher | `^1.2.3`, `~1.2.3`              | semver range (same as npm)                             |
+| DockerMatcher      | `1.25`, `1.25-alpine`, `v1.0.0` | Suffix-aware tag comparison, `resolve_latest` override |
 
 ### Registry (src/version/registry.rs)
 
@@ -353,15 +353,15 @@ pub trait Registry: Send + Sync {
 ```
 
 **Implementations:**
-| Registry | Endpoint | Notes |
-|----------|----------|-------|
-| NpmRegistry | `registry.npmjs.org/{pkg}` | dist-tags support, sorted by publish date |
-| CratesRegistry | `crates.io/api/v1/crates/{pkg}` | Excludes yanked versions |
-| GoProxyRegistry | `proxy.golang.org/{mod}/@v/list` | Module path encoding |
-| GitHubRegistry | `api.github.com/repos/{owner/repo}/releases` | Rate limit handling |
-| PypiRegistry | `pypi.org/pypi/{pkg}/json` | Excludes yanked versions |
-| JsrRegistry | `jsr.io/api/scopes/{scope}/packages/{pkg}` | JSR scoped packages |
-| DockerRegistry | Docker Hub: `registry-1.docker.io`, ghcr.io: `ghcr.io` | Token auth, tag filtering/sorting |
+| Registry        | Endpoint                                               | Notes                                     |
+| --------------- | ------------------------------------------------------ | ----------------------------------------- |
+| NpmRegistry     | `registry.npmjs.org/{pkg}`                             | dist-tags support, sorted by publish date |
+| CratesRegistry  | `crates.io/api/v1/crates/{pkg}`                        | Excludes yanked versions                  |
+| GoProxyRegistry | `proxy.golang.org/{mod}/@v/list`                       | Module path encoding                      |
+| GitHubRegistry  | `api.github.com/repos/{owner/repo}/releases`           | Rate limit handling                       |
+| PypiRegistry    | `pypi.org/pypi/{pkg}/json`                             | Excludes yanked versions                  |
+| JsrRegistry     | `jsr.io/api/scopes/{scope}/packages/{pkg}`             | JSR scoped packages                       |
+| DockerRegistry  | Docker Hub: `registry-1.docker.io`, ghcr.io: `ghcr.io` | Token auth, tag filtering/sorting         |
 
 ---
 
@@ -369,9 +369,9 @@ pub trait Registry: Send + Sync {
 
 ### File Paths
 
-| Item | Path |
-|------|------|
-| Cache DB | `$XDG_DATA_HOME/version-lsp/versions.db` or `~/.local/share/version-lsp/versions.db` |
+| Item     | Path                                                                                         |
+| -------- | -------------------------------------------------------------------------------------------- |
+| Cache DB | `$XDG_DATA_HOME/version-lsp/versions.db` or `~/.local/share/version-lsp/versions.db`         |
 | Log File | `$XDG_DATA_HOME/version-lsp/version-lsp.log` or `~/.local/share/version-lsp/version-lsp.log` |
 
 ### Configuration Structure
@@ -399,11 +399,11 @@ pub trait Registry: Send + Sync {
 
 ### Constants
 
-| Constant | Value | Description |
-|----------|-------|-------------|
-| `DEFAULT_REFRESH_INTERVAL_MS` | 86,400,000 (24 hours) | Cache refresh interval |
-| `FETCH_TIMEOUT_MS` | 30,000 (30 seconds) | Fetch lock timeout |
-| `FETCH_STAGGER_DELAY_MS` | 10 | Delay between fetch starts (rate limit mitigation) |
+| Constant                      | Value                 | Description                                        |
+| ----------------------------- | --------------------- | -------------------------------------------------- |
+| `DEFAULT_REFRESH_INTERVAL_MS` | 86,400,000 (24 hours) | Cache refresh interval                             |
+| `FETCH_TIMEOUT_MS`            | 30,000 (30 seconds)   | Fetch lock timeout                                 |
+| `FETCH_STAGGER_DELAY_MS`      | 10                    | Delay between fetch starts (rate limit mitigation) |
 
 ---
 
@@ -459,11 +459,11 @@ tests/
 
 ### Test Patterns
 
-| Type | Location | Purpose |
-|------|----------|---------|
-| Unit Tests | Within implementation files | Parser correctness, matcher logic, cache operations |
-| Integration Tests | tests/ | Component interactions |
-| E2E Tests | tests/e2e_*.rs | Complete LSP protocol flows per registry |
+| Type              | Location                    | Purpose                                             |
+| ----------------- | --------------------------- | --------------------------------------------------- |
+| Unit Tests        | Within implementation files | Parser correctness, matcher logic, cache operations |
+| Integration Tests | tests/                      | Component interactions                              |
+| E2E Tests         | tests/e2e_*.rs              | Complete LSP protocol flows per registry            |
 
 ### Test Tools
 - **mockall**: Trait mocking

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-version-lsp is a Language Server Protocol (LSP) implementation that provides version checking diagnostics for package dependency files (package.json, Cargo.toml, go.mod, GitHub Actions workflow).
+version-lsp is a Language Server Protocol (LSP) implementation that provides version checking diagnostics for package dependency files (package.json, Cargo.toml, go.mod, GitHub Actions workflow, pyproject.toml, deno.json, pnpm-workspace.yaml, compose.yaml).
 
 **Key Features:**
 - Detection and warning for outdated versions
@@ -17,6 +17,10 @@ version-lsp is a Language Server Protocol (LSP) implementation that provides ver
 | crates.io       | Cargo.toml          | Cargo requirements (`^`, `~`, `=`, `*`, etc.)|
 | Go Proxy        | go.mod              | Exact match                                  |
 | GitHub Releases | GitHub Actions YAML | Partial match (`v4` → `v4.x.x`)              |
+| PyPI            | pyproject.toml      | PEP 508 version specifiers                   |
+| JSR             | deno.json / deno.jsonc | semver range                              |
+| npm (pnpm)      | pnpm-workspace.yaml | semver range (catalog definitions)            |
+| Docker Hub / ghcr.io | compose.yaml / docker-compose.yaml | Suffix-aware tag comparison     |
 
 ---
 
@@ -48,6 +52,10 @@ version-lsp is a Language Server Protocol (LSP) implementation that provides ver
 │  • CargoToml        │  • CratesMatcher    │  • CratesRegistry       │
 │  • GoMod            │  • GoMatcher        │  • GoProxyRegistry      │
 │  • GitHubActions    │  • GitHubMatcher    │  • GitHubRegistry       │
+│  • PyprojectToml    │  • PypiMatcher      │  • PypiRegistry         │
+│  • DenoJson         │  • JsrMatcher       │  • JsrRegistry          │
+│  • PnpmWorkspace    │  • PnpmCatalog      │  (reuses NpmRegistry)   │
+│  • Compose          │  • DockerMatcher    │  • DockerRegistry       │
 └─────────────────────┴─────────────────────┴─────────────────────────┘
                                   │
                                   ▼
@@ -89,7 +97,11 @@ src/
 │   ├── package_json.rs     # npm package.json parser
 │   ├── cargo_toml.rs       # Rust Cargo.toml parser
 │   ├── github_actions.rs   # GitHub Actions workflow parser
-│   └── go_mod.rs           # Go go.mod parser
+│   ├── go_mod.rs           # Go go.mod parser
+│   ├── pyproject_toml.rs   # Python pyproject.toml parser
+│   ├── deno_json.rs        # Deno deno.json/deno.jsonc parser
+│   ├── pnpm_workspace.rs   # pnpm pnpm-workspace.yaml parser
+│   └── compose.rs          # Docker compose.yaml parser
 │
 └── version/                 # Version Management Layer
     ├── mod.rs              # Module documentation & architecture diagram
@@ -106,14 +118,21 @@ src/
     │   ├── npm.rs          # npm registry API client
     │   ├── crates_io.rs    # crates.io API client
     │   ├── github.rs       # GitHub Releases API client
-    │   └── go_proxy.rs     # Go Proxy API client
+    │   ├── go_proxy.rs     # Go Proxy API client
+    │   ├── pypi.rs         # PyPI API client
+    │   ├── jsr.rs          # JSR API client
+    │   └── docker.rs       # Docker Hub / ghcr.io API client
     │
     └── matchers/           # Version Matcher Implementations
         ├── mod.rs
         ├── npm.rs          # npm semver range matching
         ├── crates.rs       # Cargo version requirements
         ├── github_actions.rs # GitHub Actions partial version matching
-        └── go.rs           # Go exact matching
+        ├── go.rs           # Go exact matching
+        ├── pypi.rs         # PyPI PEP 508 matching
+        ├── jsr.rs          # JSR semver range matching
+        ├── pnpm_catalog.rs # pnpm catalog (reuses npm matching)
+        └── docker.rs       # Docker suffix-aware tag matching
 ```
 
 ---
@@ -303,6 +322,9 @@ pub trait VersionMatcher: Send + Sync {
     fn registry_type(&self) -> RegistryType;
     fn version_exists(&self, version_spec: &str, available_versions: &[String]) -> bool;
     fn compare_to_latest(&self, current: &str, latest: &str) -> CompareResult;
+    fn resolve_latest(&self, current: &str, latest: &str, all_versions: &[String]) -> String {
+        latest.to_string() // default: return latest as-is
+    }
 }
 ```
 
@@ -313,6 +335,10 @@ pub trait VersionMatcher: Send + Sync {
 | CratesMatcher | `1.2.3`, `~1.2`, `>=1, <2` | Cargo requirements |
 | GoMatcher | `v1.2.3` | Exact match |
 | GitHubMatcher | `v4`, `v4.1` | Partial match (major/minor) |
+| PypiMatcher | `>=1.0,<2.0`, `~=1.4` | PEP 508 version specifiers |
+| JsrMatcher | `^1.2.3`, `~1.2.3` | semver range evaluation |
+| PnpmCatalogMatcher | `^1.2.3`, `~1.2.3` | semver range (same as npm) |
+| DockerMatcher | `1.25`, `1.25-alpine`, `v1.0.0` | Suffix-aware tag comparison, `resolve_latest` override |
 
 ### Registry (src/version/registry.rs)
 
@@ -333,6 +359,9 @@ pub trait Registry: Send + Sync {
 | CratesRegistry | `crates.io/api/v1/crates/{pkg}` | Excludes yanked versions |
 | GoProxyRegistry | `proxy.golang.org/{mod}/@v/list` | Module path encoding |
 | GitHubRegistry | `api.github.com/repos/{owner/repo}/releases` | Rate limit handling |
+| PypiRegistry | `pypi.org/pypi/{pkg}/json` | Excludes yanked versions |
+| JsrRegistry | `jsr.io/api/scopes/{scope}/packages/{pkg}` | JSR scoped packages |
+| DockerRegistry | Docker Hub: `registry-1.docker.io`, ghcr.io: `ghcr.io` | Token auth, tag filtering/sorting |
 
 ---
 
@@ -357,7 +386,11 @@ pub trait Registry: Send + Sync {
       "npm": { "enabled": true },
       "crates": { "enabled": true },
       "goProxy": { "enabled": true },
-      "github": { "enabled": true }
+      "github": { "enabled": true },
+      "pypi": { "enabled": true },
+      "pnpmCatalog": { "enabled": true },
+      "jsr": { "enabled": true },
+      "docker": { "enabled": true }
     },
     "ignorePrerelease": true
   }
@@ -413,7 +446,15 @@ src/
 ├── **/mod.rs          # Each module has #[cfg(test)] mod tests
 │
 tests/
-└── lsp_e2e_test.rs    # E2E LSP protocol tests
+├── helper/            # Shared test utilities (mock registry, LSP helpers)
+├── e2e_npm.rs         # npm E2E tests
+├── e2e_crates.rs      # crates.io E2E tests
+├── e2e_go.rs          # Go Proxy E2E tests
+├── e2e_pypi.rs        # PyPI E2E tests
+├── e2e_github.rs      # GitHub Actions E2E tests
+├── e2e_jsr.rs         # JSR E2E tests
+├── e2e_pnpm.rs        # pnpm catalog E2E tests
+└── e2e_docker.rs      # Docker Hub / ghcr.io E2E tests
 ```
 
 ### Test Patterns
@@ -422,7 +463,7 @@ tests/
 |------|----------|---------|
 | Unit Tests | Within implementation files | Parser correctness, matcher logic, cache operations |
 | Integration Tests | tests/ | Component interactions |
-| E2E Tests | tests/lsp_e2e_test.rs | Complete LSP protocol flows |
+| E2E Tests | tests/e2e_*.rs | Complete LSP protocol flows per registry |
 
 ### Test Tools
 - **mockall**: Trait mocking

--- a/src/config.rs
+++ b/src/config.rs
@@ -63,6 +63,7 @@ pub struct RegistriesConfig {
     pub pnpm_catalog: RegistryConfig,
     pub jsr: RegistryConfig,
     pub pypi: RegistryConfig,
+    pub docker: RegistryConfig,
 }
 
 /// Individual registry configuration
@@ -155,6 +156,7 @@ mod tests {
                     pnpm_catalog: RegistryConfig { enabled: false },
                     jsr: RegistryConfig { enabled: false },
                     pypi: RegistryConfig { enabled: true },
+                    docker: RegistryConfig { enabled: true },
                 },
                 ignore_prerelease: true,
             }

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -118,6 +118,7 @@ impl<S: VersionStorer> Backend<S> {
             RegistryType::PnpmCatalog => config.registries.pnpm_catalog.enabled,
             RegistryType::Jsr => config.registries.jsr.enabled,
             RegistryType::PyPI => config.registries.pypi.enabled,
+            RegistryType::Docker => config.registries.docker.enabled,
         }
     }
 

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -458,14 +458,26 @@ impl<S: VersionStorer> LanguageServer for Backend<S> {
             package.name, package.version
         );
 
+        let Some(resolver) = self.resolvers.get(&registry_type) else {
+            debug!("No resolver for registry type {:?}", registry_type);
+            return Ok(None);
+        };
+
         // For GitHub Actions with commit hash, use async function to fetch SHA
         let actions = if package.registry_type == RegistryType::GitHubActions
             && package.commit_hash.is_some()
         {
             let sha_fetcher = GitHubRegistry::default();
-            generate_bump_code_actions_with_sha(&**storer, package, uri, &sha_fetcher).await
+            generate_bump_code_actions_with_sha(
+                &**storer,
+                package,
+                uri,
+                &sha_fetcher,
+                &**resolver.matcher(),
+            )
+            .await
         } else {
-            generate_bump_code_actions(&**storer, package, uri)
+            generate_bump_code_actions(&**storer, package, uri, &**resolver.matcher())
         };
 
         if actions.is_empty() {

--- a/src/lsp/code_action.rs
+++ b/src/lsp/code_action.rs
@@ -2,10 +2,8 @@
 
 use crate::parser::types::{ExtraInfo, PackageInfo};
 use crate::version::checker::VersionStorer;
+use crate::version::matcher::VersionMatcher;
 use crate::version::registries::github::TagShaFetcher;
-use crate::version::semver::{
-    calculate_latest_major, calculate_latest_minor, calculate_latest_patch,
-};
 use std::collections::HashMap;
 use tower_lsp::lsp_types::{
     CodeAction, CodeActionKind, Position, Range, TextEdit, Url, WorkspaceEdit,
@@ -76,6 +74,7 @@ pub fn generate_bump_code_actions<S: VersionStorer>(
     storer: &S,
     package: &PackageInfo,
     uri: &Url,
+    matcher: &dyn VersionMatcher,
 ) -> Vec<CodeAction> {
     let Ok(versions) = storer.get_versions(package.registry_type, &package.name) else {
         return vec![];
@@ -88,10 +87,9 @@ pub fn generate_bump_code_actions<S: VersionStorer>(
     let current = &package.version;
     let prefix = extract_version_prefix(current);
 
-    // Calculate bump targets
-    let patch = calculate_latest_patch(current, &versions);
-    let minor = calculate_latest_minor(current, &versions);
-    let major = calculate_latest_major(current, &versions);
+    // Calculate bump targets via matcher (registry-specific logic)
+    let targets = matcher.calculate_bump_targets(current, &versions);
+    let (patch, minor, major) = (targets.patch, targets.minor, targets.major);
 
     // Collect unique bump targets with their labels
     let mut seen = std::collections::HashSet::new();
@@ -160,6 +158,7 @@ pub async fn generate_bump_code_actions_with_sha<S: VersionStorer, F: TagShaFetc
     package: &PackageInfo,
     uri: &Url,
     sha_fetcher: &F,
+    matcher: &dyn VersionMatcher,
 ) -> Vec<CodeAction> {
     let Ok(versions) = storer.get_versions(package.registry_type, &package.name) else {
         return vec![];
@@ -181,10 +180,9 @@ pub async fn generate_bump_code_actions_with_sha<S: VersionStorer, F: TagShaFetc
     let current = &package.version;
     let prefix = extract_version_prefix(current);
 
-    // Calculate bump targets
-    let patch = calculate_latest_patch(current, &versions);
-    let minor = calculate_latest_minor(current, &versions);
-    let major = calculate_latest_major(current, &versions);
+    // Calculate bump targets via matcher (registry-specific logic)
+    let targets = matcher.calculate_bump_targets(current, &versions);
+    let (patch, minor, major) = (targets.patch, targets.minor, targets.major);
 
     // Collect unique bump targets with their labels
     let mut seen = std::collections::HashSet::new();
@@ -328,6 +326,7 @@ mod tests {
     use crate::parser::types::RegistryType;
     use crate::version::cache::PackageId;
     use crate::version::error::CacheError;
+    use crate::version::matchers::{GitHubActionsMatcher, NpmVersionMatcher};
     use rstest::rstest;
 
     fn make_package(name: &str, version: &str, line: u32, column: u32, len: usize) -> PackageInfo {
@@ -492,7 +491,7 @@ mod tests {
         let package = make_package("lodash", "4.17.19", 3, 15, 7);
         let uri = Url::parse("file:///test/package.json").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert_eq!(actions.len(), 3);
         assert_eq!(actions[0].title, "Bump to latest patch: 4.17.21");
@@ -506,7 +505,7 @@ mod tests {
         let package = make_package("lodash", "4.17.19", 3, 15, 7);
         let uri = Url::parse("file:///test/package.json").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert!(actions.is_empty());
     }
@@ -517,7 +516,7 @@ mod tests {
         let package = make_package("lodash", "5.0.0", 3, 15, 5);
         let uri = Url::parse("file:///test/package.json").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert!(actions.is_empty());
     }
@@ -528,7 +527,7 @@ mod tests {
         let package = make_package("lodash", "4.17.19", 3, 15, 7);
         let uri = Url::parse("file:///test/package.json").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert_eq!(actions.len(), 1);
         let edit = actions[0].edit.as_ref().unwrap();
@@ -557,7 +556,7 @@ mod tests {
         let package = make_package("lodash", "^4.17.19", 3, 15, 8);
         let uri = Url::parse("file:///test/package.json").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert_eq!(actions.len(), 3);
         assert_eq!(actions[0].title, "Bump to latest patch: ^4.17.21");
@@ -577,7 +576,7 @@ mod tests {
         let package = make_package("lodash", "~4.17.19", 3, 15, 8);
         let uri = Url::parse("file:///test/package.json").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Bump to latest patch: ~4.17.21");
@@ -589,7 +588,7 @@ mod tests {
         let package = make_package("lodash", ">=4.17.19", 3, 15, 9);
         let uri = Url::parse("file:///test/package.json").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Bump to latest major: >=5.0.0");
@@ -601,7 +600,7 @@ mod tests {
         let package = make_package("golang.org/x/text", "v0.14.0", 3, 15, 7);
         let uri = Url::parse("file:///test/go.mod").unwrap();
 
-        let actions = generate_bump_code_actions(&storer, &package, &uri);
+        let actions = generate_bump_code_actions(&storer, &package, &uri, &NpmVersionMatcher);
 
         assert_eq!(actions.len(), 2);
         assert_eq!(actions[0].title, "Bump to latest minor: v0.15.0");
@@ -717,8 +716,14 @@ mod tests {
         );
         let uri = Url::parse("file:///test/.github/workflows/ci.yml").unwrap();
 
-        let actions =
-            generate_bump_code_actions_with_sha(&storer, &package, &uri, &sha_fetcher).await;
+        let actions = generate_bump_code_actions_with_sha(
+            &storer,
+            &package,
+            &uri,
+            &sha_fetcher,
+            &GitHubActionsMatcher,
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         // For hash-only packages, we don't know the current version, so just offer "Bump to latest"
@@ -759,8 +764,14 @@ mod tests {
         );
         let uri = Url::parse("file:///test/.github/workflows/ci.yml").unwrap();
 
-        let actions =
-            generate_bump_code_actions_with_sha(&storer, &package, &uri, &sha_fetcher).await;
+        let actions = generate_bump_code_actions_with_sha(
+            &storer,
+            &package,
+            &uri,
+            &sha_fetcher,
+            &GitHubActionsMatcher,
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Bump to latest patch: v4.1.6");
@@ -794,8 +805,14 @@ mod tests {
         );
         let uri = Url::parse("file:///test/.github/workflows/ci.yml").unwrap();
 
-        let actions =
-            generate_bump_code_actions_with_sha(&storer, &package, &uri, &sha_fetcher).await;
+        let actions = generate_bump_code_actions_with_sha(
+            &storer,
+            &package,
+            &uri,
+            &sha_fetcher,
+            &GitHubActionsMatcher,
+        )
+        .await;
 
         assert!(actions.is_empty());
     }
@@ -808,8 +825,14 @@ mod tests {
         let package = make_package("actions/checkout", "v3.0.0", 4, 31, 6);
         let uri = Url::parse("file:///test/.github/workflows/ci.yml").unwrap();
 
-        let actions =
-            generate_bump_code_actions_with_sha(&storer, &package, &uri, &sha_fetcher).await;
+        let actions = generate_bump_code_actions_with_sha(
+            &storer,
+            &package,
+            &uri,
+            &sha_fetcher,
+            &GitHubActionsMatcher,
+        )
+        .await;
 
         assert_eq!(actions.len(), 1);
         assert_eq!(actions[0].title, "Bump to latest major: v4.0.0");

--- a/src/lsp/resolver.rs
+++ b/src/lsp/resolver.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use crate::parser::cargo_toml::CargoTomlParser;
+use crate::parser::compose::ComposeParser;
 use crate::parser::deno_json::DenoJsonParser;
 use crate::parser::github_actions::GitHubActionsParser;
 use crate::parser::go_mod::GoModParser;
@@ -17,10 +18,11 @@ use crate::parser::traits::Parser;
 use crate::parser::types::RegistryType;
 use crate::version::matcher::VersionMatcher;
 use crate::version::matchers::{
-    CratesVersionMatcher, GitHubActionsMatcher, GoVersionMatcher, JsrVersionMatcher,
-    NpmVersionMatcher, PnpmCatalogMatcher, PypiVersionMatcher,
+    CratesVersionMatcher, DockerVersionMatcher, GitHubActionsMatcher, GoVersionMatcher,
+    JsrVersionMatcher, NpmVersionMatcher, PnpmCatalogMatcher, PypiVersionMatcher,
 };
 use crate::version::registries::crates_io::CratesIoRegistry;
+use crate::version::registries::docker::DockerRegistry;
 use crate::version::registries::github::GitHubRegistry;
 use crate::version::registries::go_proxy::GoProxyRegistry;
 use crate::version::registries::jsr::JsrRegistry;
@@ -136,6 +138,15 @@ pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
             Arc::new(PyprojectTomlParser::new()),
             Arc::new(PypiVersionMatcher),
             Arc::new(PypiRegistry::default()),
+        ),
+    );
+
+    resolvers.insert(
+        RegistryType::Docker,
+        PackageResolver::new(
+            Arc::new(ComposeParser::new()),
+            Arc::new(DockerVersionMatcher),
+            Arc::new(DockerRegistry::default()),
         ),
     );
 

--- a/src/parser/compose.rs
+++ b/src/parser/compose.rs
@@ -1,0 +1,392 @@
+//! Docker Compose file parser
+//!
+//! Parses compose.yaml / docker-compose.yaml to extract container image tags.
+//! Supports Docker Hub (official and user images) and ghcr.io images.
+
+use crate::parser::traits::{ParseError, Parser};
+use crate::parser::types::{PackageInfo, RegistryType};
+use tracing::warn;
+
+/// Parser for compose.yaml / docker-compose.yaml files
+#[derive(Default)]
+pub struct ComposeParser;
+
+impl ComposeParser {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Parser for ComposeParser {
+    fn parse(&self, content: &str) -> Result<Vec<PackageInfo>, ParseError> {
+        let mut parser = tree_sitter::Parser::new();
+        let language = tree_sitter_yaml::LANGUAGE;
+        parser.set_language(&language.into()).map_err(|e| {
+            warn!("Failed to set YAML language for tree-sitter: {}", e);
+            ParseError::TreeSitter(e.to_string())
+        })?;
+
+        let tree = parser.parse(content, None).ok_or_else(|| {
+            warn!("Failed to parse YAML content");
+            ParseError::ParseFailed("Failed to parse YAML".to_string())
+        })?;
+
+        let root = tree.root_node();
+        let mut results = Vec::new();
+
+        find_services_images(root, content, &mut results);
+
+        Ok(results)
+    }
+}
+
+/// Find services section and extract image fields
+fn find_services_images(node: tree_sitter::Node, content: &str, results: &mut Vec<PackageInfo>) {
+    if node.kind() == "block_mapping_pair"
+        && let Some(key_node) = node.child_by_field_name("key")
+    {
+        let key = get_node_text(key_node, content);
+        if key == "services" {
+            if let Some(value_node) = node.child_by_field_name("value") {
+                extract_service_images(value_node, content, results);
+            }
+            return;
+        }
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        find_services_images(child, content, results);
+    }
+}
+
+/// Extract image fields from each service definition
+fn extract_service_images(node: tree_sitter::Node, content: &str, results: &mut Vec<PackageInfo>) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "block_mapping" {
+            // Each child of block_mapping is a service definition
+            let mut inner_cursor = child.walk();
+            for service_pair in child.children(&mut inner_cursor) {
+                if service_pair.kind() == "block_mapping_pair"
+                    && let Some(value_node) = service_pair.child_by_field_name("value")
+                {
+                    extract_image_from_service(value_node, content, results);
+                }
+            }
+        }
+    }
+}
+
+/// Extract the image field from a service's mapping
+fn extract_image_from_service(
+    node: tree_sitter::Node,
+    content: &str,
+    results: &mut Vec<PackageInfo>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "block_mapping" {
+            let mut inner_cursor = child.walk();
+            for pair in child.children(&mut inner_cursor) {
+                if pair.kind() == "block_mapping_pair"
+                    && let Some(key_node) = pair.child_by_field_name("key")
+                {
+                    let key = get_node_text(key_node, content);
+                    if key == "image"
+                        && let Some(value_node) = pair.child_by_field_name("value")
+                        && let Some(info) = parse_image_value(value_node, content)
+                    {
+                        results.push(info);
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Parse an image value like "nginx:1.25" or "ghcr.io/owner/repo:v1.0.0"
+fn parse_image_value(node: tree_sitter::Node, content: &str) -> Option<PackageInfo> {
+    let raw_text = &content[node.byte_range()];
+    let trimmed = raw_text.trim();
+
+    // Remove quotes if present
+    let image_ref = if (trimmed.starts_with('\'') && trimmed.ends_with('\''))
+        || (trimmed.starts_with('"') && trimmed.ends_with('"'))
+    {
+        &trimmed[1..trimmed.len() - 1]
+    } else {
+        trimmed
+    };
+
+    // Skip variable expansions
+    if image_ref.contains("${") || image_ref.contains("$") {
+        return None;
+    }
+
+    // Skip digest references
+    if image_ref.contains('@') {
+        return None;
+    }
+
+    // Split image:tag
+    let (image_name, tag) = image_ref.rsplit_once(':')?;
+
+    // Skip "latest" tag
+    if tag == "latest" {
+        return None;
+    }
+
+    // Skip empty tag
+    if tag.is_empty() {
+        return None;
+    }
+
+    // Determine registry and normalize name
+    let name = resolve_image_name(image_name)?;
+
+    // Calculate offset for the tag part (after the colon)
+    let colon_pos = image_ref.rfind(':')?;
+    let value_start = node.start_byte();
+
+    // Account for quotes
+    let quote_offset = if raw_text.trim().starts_with('"') || raw_text.trim().starts_with('\'') {
+        1
+    } else {
+        0
+    };
+
+    // Find where the actual text starts within the node (skip leading whitespace)
+    let leading_whitespace = raw_text.len() - raw_text.trim_start().len();
+
+    let tag_start_offset = value_start + leading_whitespace + quote_offset + colon_pos + 1;
+    let tag_end_offset = tag_start_offset + tag.len();
+
+    // Calculate line/column from tag start offset
+    let (line, column) = offset_to_line_col(content, tag_start_offset);
+
+    Some(PackageInfo {
+        name,
+        version: tag.to_string(),
+        commit_hash: None,
+        registry_type: RegistryType::Docker,
+        start_offset: tag_start_offset,
+        end_offset: tag_end_offset,
+        line,
+        column,
+        extra_info: None,
+    })
+}
+
+/// Resolve image name to registry-appropriate format.
+///
+/// - `nginx` → `library/nginx` (Docker Hub official)
+/// - `myuser/myapp` → `myuser/myapp` (Docker Hub user)
+/// - `ghcr.io/owner/repo` → `ghcr.io/owner/repo` (GitHub Container Registry)
+/// - `mcr.microsoft.com/...` → None (unsupported)
+fn resolve_image_name(image_name: &str) -> Option<String> {
+    // Check if it has a domain (contains '.')
+    if let Some((domain, _rest)) = image_name.split_once('/')
+        && domain.contains('.')
+    {
+        if domain == "ghcr.io" {
+            return Some(image_name.to_string());
+        }
+        // Unsupported third-party registries
+        return None;
+    }
+
+    // Docker Hub: no domain part
+    if image_name.contains('/') {
+        // User image: myuser/myapp
+        Some(image_name.to_string())
+    } else {
+        // Official image: nginx → library/nginx
+        Some(format!("library/{}", image_name))
+    }
+}
+
+/// Calculate line (0-indexed) and column (0-indexed) from byte offset
+fn offset_to_line_col(content: &str, offset: usize) -> (usize, usize) {
+    let mut line = 0;
+    let mut col = 0;
+    for (i, ch) in content.char_indices() {
+        if i >= offset {
+            break;
+        }
+        if ch == '\n' {
+            line += 1;
+            col = 0;
+        } else {
+            col += 1;
+        }
+    }
+    (line, col)
+}
+
+/// Get text content of a node, removing quotes if present
+fn get_node_text(node: tree_sitter::Node, content: &str) -> String {
+    let text = &content[node.byte_range()];
+    text.trim()
+        .trim_start_matches('"')
+        .trim_end_matches('"')
+        .trim_start_matches('\'')
+        .trim_end_matches('\'')
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn parse_extracts_docker_hub_official_image() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: nginx:1.25\n";
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            PackageInfo {
+                name: "library/nginx".to_string(),
+                version: "1.25".to_string(),
+                commit_hash: None,
+                registry_type: RegistryType::Docker,
+                start_offset: 34,
+                end_offset: 38,
+                line: 2,
+                column: 17,
+                extra_info: None,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_extracts_docker_hub_user_image() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  app:\n    image: myuser/myapp:v1.0.0\n";
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "myuser/myapp");
+        assert_eq!(result[0].version, "v1.0.0");
+    }
+
+    #[test]
+    fn parse_extracts_ghcr_image() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  app:\n    image: ghcr.io/owner/repo:v1.0.0\n";
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "ghcr.io/owner/repo");
+        assert_eq!(result[0].version, "v1.0.0");
+    }
+
+    #[test]
+    fn parse_extracts_multiple_services() {
+        let parser = ComposeParser::new();
+        let content = r#"services:
+  web:
+    image: nginx:1.25
+  db:
+    image: postgres:15
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "library/nginx");
+        assert_eq!(result[0].version, "1.25");
+        assert_eq!(result[1].name, "library/postgres");
+        assert_eq!(result[1].version, "15");
+    }
+
+    #[test]
+    fn parse_skips_image_without_tag() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: nginx\n";
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_latest_tag() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: nginx:latest\n";
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_digest_reference() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: nginx@sha256:abc123def456\n";
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_variable_expansion() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: ${IMAGE_NAME}:${TAG}\n";
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_unsupported_registry() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: mcr.microsoft.com/dotnet/sdk:8.0\n";
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_service_with_build_only() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  app:\n    build: .\n";
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_handles_suffixed_tag() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: nginx:1.25-alpine\n";
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "library/nginx");
+        assert_eq!(result[0].version, "1.25-alpine");
+    }
+
+    #[test]
+    fn parse_handles_quoted_image() {
+        let parser = ComposeParser::new();
+        let content = "services:\n  web:\n    image: \"nginx:1.25\"\n";
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "library/nginx");
+        assert_eq!(result[0].version, "1.25");
+    }
+
+    #[rstest]
+    #[case("nginx", None)]
+    #[case("myuser/myapp", Some("myuser/myapp"))]
+    #[case("ghcr.io/owner/repo", Some("ghcr.io/owner/repo"))]
+    #[case("mcr.microsoft.com/dotnet/sdk", None)]
+    #[case("quay.io/prometheus/node-exporter", None)]
+    fn resolve_image_name_returns_expected(#[case] input: &str, #[case] expected: Option<&str>) {
+        // Special case for official images
+        if input == "nginx" {
+            assert_eq!(resolve_image_name(input), Some("library/nginx".to_string()));
+        } else {
+            assert_eq!(resolve_image_name(input), expected.map(|s| s.to_string()));
+        }
+    }
+
+    #[test]
+    fn parse_returns_empty_for_non_compose_yaml() {
+        let parser = ComposeParser::new();
+        let content = "name: test\nversion: 1.0\n";
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/src/parser/compose.rs
+++ b/src/parser/compose.rs
@@ -368,18 +368,13 @@ mod tests {
     }
 
     #[rstest]
-    #[case("nginx", None)]
+    #[case("nginx", Some("library/nginx"))]
     #[case("myuser/myapp", Some("myuser/myapp"))]
     #[case("ghcr.io/owner/repo", Some("ghcr.io/owner/repo"))]
     #[case("mcr.microsoft.com/dotnet/sdk", None)]
     #[case("quay.io/prometheus/node-exporter", None)]
     fn resolve_image_name_returns_expected(#[case] input: &str, #[case] expected: Option<&str>) {
-        // Special case for official images
-        if input == "nginx" {
-            assert_eq!(resolve_image_name(input), Some("library/nginx".to_string()));
-        } else {
-            assert_eq!(resolve_image_name(input), expected.map(|s| s.to_string()));
-        }
+        assert_eq!(resolve_image_name(input), expected.map(|s| s.to_string()));
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -10,6 +10,7 @@
 //! - pyproject_toml.rs: pyproject.toml parser
 
 pub mod cargo_toml;
+pub mod compose;
 pub mod deno_json;
 pub mod github_actions;
 pub mod go_mod;
@@ -20,6 +21,7 @@ pub mod traits;
 pub mod types;
 
 pub use cargo_toml::CargoTomlParser;
+pub use compose::ComposeParser;
 pub use deno_json::DenoJsonParser;
 pub use github_actions::GitHubActionsParser;
 pub use go_mod::GoModParser;

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -17,6 +17,8 @@ pub enum RegistryType {
     Jsr,
     /// PyPI (pyproject.toml)
     PyPI,
+    /// Docker (compose.yaml)
+    Docker,
 }
 
 impl RegistryType {
@@ -30,6 +32,7 @@ impl RegistryType {
             RegistryType::PnpmCatalog => "pnpm_catalog",
             RegistryType::Jsr => "jsr",
             RegistryType::PyPI => "pypi",
+            RegistryType::Docker => "docker",
         }
     }
 }
@@ -46,6 +49,7 @@ impl std::str::FromStr for RegistryType {
             "pnpm_catalog" => Ok(RegistryType::PnpmCatalog),
             "jsr" => Ok(RegistryType::Jsr),
             "pypi" => Ok(RegistryType::PyPI),
+            "docker" => Ok(RegistryType::Docker),
             _ => Err(()),
         }
     }
@@ -67,9 +71,18 @@ pub fn detect_parser_type(uri: &str) -> Option<RegistryType> {
         Some(RegistryType::Jsr)
     } else if uri.ends_with("/pyproject.toml") {
         Some(RegistryType::PyPI)
+    } else if is_compose_file(uri) {
+        Some(RegistryType::Docker)
     } else {
         None
     }
+}
+
+fn is_compose_file(uri: &str) -> bool {
+    uri.ends_with("/compose.yaml")
+        || uri.ends_with("/compose.yml")
+        || uri.ends_with("/docker-compose.yaml")
+        || uri.ends_with("/docker-compose.yml")
 }
 
 fn is_github_actions_workflow(uri: &str) -> bool {
@@ -204,6 +217,11 @@ mod tests {
     #[case("/path/to/pyproject.toml", Some(RegistryType::PyPI))]
     #[case("/project/pyproject.toml", Some(RegistryType::PyPI))]
     #[case("file:///home/user/pyproject.toml", Some(RegistryType::PyPI))]
+    #[case("/path/to/compose.yaml", Some(RegistryType::Docker))]
+    #[case("/path/to/compose.yml", Some(RegistryType::Docker))]
+    #[case("/path/to/docker-compose.yaml", Some(RegistryType::Docker))]
+    #[case("/path/to/docker-compose.yml", Some(RegistryType::Docker))]
+    #[case("file:///home/user/compose.yaml", Some(RegistryType::Docker))]
     #[case("workflow.yml", None)]
     #[case("random.txt", None)]
     fn detect_parser_type_returns_expected(

--- a/src/version/checker.rs
+++ b/src/version/checker.rs
@@ -188,8 +188,11 @@ pub fn compare_version<S: VersionStorer>(
     let all_versions = storer.get_versions(registry_type, package_name)?;
     let version_exists = matcher.version_exists(&resolved_version, &all_versions);
 
+    // Let matcher resolve the effective latest version (e.g., Docker suffix matching)
+    let effective_latest = matcher.resolve_latest(&resolved_version, &latest, &all_versions);
+
     // Compare versions
-    let status = match matcher.compare_to_latest(&resolved_version, &latest) {
+    let status = match matcher.compare_to_latest(&resolved_version, &effective_latest) {
         CompareResult::Invalid => VersionStatus::Invalid,
         _ if !version_exists => VersionStatus::NotFound,
         CompareResult::Latest => VersionStatus::Latest,
@@ -199,7 +202,7 @@ pub fn compare_version<S: VersionStorer>(
 
     Ok(VersionCompareResult {
         current_version: current_version.to_string(),
-        latest_version: Some(latest),
+        latest_version: Some(effective_latest),
         status,
     })
 }

--- a/src/version/matcher.rs
+++ b/src/version/matcher.rs
@@ -1,7 +1,17 @@
 //! Version matching abstraction for different registries
 
 use crate::parser::types::RegistryType;
-use crate::version::semver::CompareResult;
+use crate::version::semver::{
+    CompareResult, calculate_latest_major, calculate_latest_minor, calculate_latest_patch,
+};
+
+/// Bump target versions for patch, minor, and major
+#[derive(Debug, Default)]
+pub struct BumpTargets {
+    pub patch: Option<String>,
+    pub minor: Option<String>,
+    pub major: Option<String>,
+}
 
 /// Trait for registry-specific version matching logic
 ///
@@ -34,5 +44,21 @@ pub trait VersionMatcher: Send + Sync {
         _all_versions: &[String],
     ) -> String {
         latest_version.to_string()
+    }
+
+    /// Calculate bump targets (patch, minor, major) for code actions.
+    ///
+    /// Default implementation uses semver-based calculation.
+    /// Docker overrides this to handle suffix-aware tag comparison.
+    fn calculate_bump_targets(
+        &self,
+        current_version: &str,
+        available_versions: &[String],
+    ) -> BumpTargets {
+        BumpTargets {
+            patch: calculate_latest_patch(current_version, available_versions),
+            minor: calculate_latest_minor(current_version, available_versions),
+            major: calculate_latest_major(current_version, available_versions),
+        }
     }
 }

--- a/src/version/matcher.rs
+++ b/src/version/matcher.rs
@@ -22,4 +22,17 @@ pub trait VersionMatcher: Send + Sync {
     ///
     /// Returns whether the current version is latest, outdated, newer, or invalid
     fn compare_to_latest(&self, current_version: &str, latest_version: &str) -> CompareResult;
+
+    /// Find the appropriate "latest" version for comparison based on current version context.
+    ///
+    /// Default: returns latest_version unchanged (existing matchers are unaffected).
+    /// Docker: finds the latest version with the same suffix pattern (e.g., `-alpine`).
+    fn resolve_latest(
+        &self,
+        _current_version: &str,
+        latest_version: &str,
+        _all_versions: &[String],
+    ) -> String {
+        latest_version.to_string()
+    }
 }

--- a/src/version/matchers/docker.rs
+++ b/src/version/matchers/docker.rs
@@ -154,13 +154,13 @@ impl VersionMatcher for DockerVersionMatcher {
 }
 
 /// Parsed Docker tag components
-struct ParsedDockerTag {
+pub(crate) struct ParsedDockerTag {
     /// The numeric version part (e.g., "1.25.0")
-    version_part: String,
+    pub(crate) version_part: String,
     /// The suffix after the version (e.g., "-alpine"), empty if none
-    suffix: String,
+    pub(crate) suffix: String,
     /// Parsed semver
-    semver: Version,
+    pub(crate) semver: Version,
 }
 
 /// Parse a Docker tag into version part and suffix.
@@ -170,7 +170,7 @@ struct ParsedDockerTag {
 /// - "16-alpine" → version_part="16", suffix="-alpine"
 /// - "v1.0.0" → version_part="1.0.0", suffix=""
 /// - "1.25" → version_part="1.25", suffix=""
-fn parse_docker_tag(tag: &str) -> Option<ParsedDockerTag> {
+pub(crate) fn parse_docker_tag(tag: &str) -> Option<ParsedDockerTag> {
     // Strip v/V prefix
     let tag = tag.strip_prefix('v').unwrap_or(tag);
     let tag = tag.strip_prefix('V').unwrap_or(tag);

--- a/src/version/matchers/docker.rs
+++ b/src/version/matchers/docker.rs
@@ -1,0 +1,303 @@
+//! Docker container image tag version matcher
+//!
+//! Handles version comparison for Docker image tags with suffix support.
+//! Tags like "1.25-alpine" are split into version part "1.25" and suffix "-alpine".
+//! The matcher prefers comparing within the same suffix group.
+
+use semver::Version;
+use tracing::warn;
+
+use crate::parser::types::RegistryType;
+use crate::version::matcher::VersionMatcher;
+use crate::version::semver::CompareResult;
+
+pub struct DockerVersionMatcher;
+
+impl VersionMatcher for DockerVersionMatcher {
+    fn registry_type(&self) -> RegistryType {
+        RegistryType::Docker
+    }
+
+    fn version_exists(&self, version_spec: &str, available_versions: &[String]) -> bool {
+        available_versions.iter().any(|v| v == version_spec)
+    }
+
+    fn compare_to_latest(&self, current_version: &str, latest_version: &str) -> CompareResult {
+        let Some(current_parsed) = parse_docker_tag(current_version) else {
+            warn!("Invalid Docker tag format: '{}'", current_version);
+            return CompareResult::Invalid;
+        };
+
+        let Some(latest_parsed) = parse_docker_tag(latest_version) else {
+            warn!("Invalid Docker tag format: '{}'", latest_version);
+            return CompareResult::Invalid;
+        };
+
+        let parts = count_version_parts(&current_parsed.version_part);
+
+        match parts {
+            1 => match current_parsed.semver.major.cmp(&latest_parsed.semver.major) {
+                std::cmp::Ordering::Equal => CompareResult::Latest,
+                std::cmp::Ordering::Less => CompareResult::Outdated,
+                std::cmp::Ordering::Greater => CompareResult::Newer,
+            },
+            2 => {
+                match (current_parsed.semver.major, current_parsed.semver.minor)
+                    .cmp(&(latest_parsed.semver.major, latest_parsed.semver.minor))
+                {
+                    std::cmp::Ordering::Equal => CompareResult::Latest,
+                    std::cmp::Ordering::Less => CompareResult::Outdated,
+                    std::cmp::Ordering::Greater => CompareResult::Newer,
+                }
+            }
+            _ => match current_parsed.semver.cmp(&latest_parsed.semver) {
+                std::cmp::Ordering::Equal => CompareResult::Latest,
+                std::cmp::Ordering::Less => CompareResult::Outdated,
+                std::cmp::Ordering::Greater => CompareResult::Newer,
+            },
+        }
+    }
+
+    fn resolve_latest(
+        &self,
+        current_version: &str,
+        latest_version: &str,
+        all_versions: &[String],
+    ) -> String {
+        let Some(current_parsed) = parse_docker_tag(current_version) else {
+            return latest_version.to_string();
+        };
+
+        let suffix = &current_parsed.suffix;
+
+        // If no suffix, just return the latest_version as-is
+        if suffix.is_empty() {
+            return latest_version.to_string();
+        }
+
+        // Find the best version with the same suffix
+        let best_same_suffix = all_versions
+            .iter()
+            .filter_map(|v| {
+                let parsed = parse_docker_tag(v)?;
+                if parsed.suffix == *suffix {
+                    Some((v.clone(), parsed))
+                } else {
+                    None
+                }
+            })
+            .max_by(|(_, a), (_, b)| a.semver.cmp(&b.semver));
+
+        match best_same_suffix {
+            Some((tag, parsed)) if parsed.semver > current_parsed.semver => tag,
+            _ => latest_version.to_string(),
+        }
+    }
+}
+
+/// Parsed Docker tag components
+struct ParsedDockerTag {
+    /// The numeric version part (e.g., "1.25.0")
+    version_part: String,
+    /// The suffix after the version (e.g., "-alpine"), empty if none
+    suffix: String,
+    /// Parsed semver
+    semver: Version,
+}
+
+/// Parse a Docker tag into version part and suffix.
+///
+/// Examples:
+/// - "1.25.0-alpine" → version_part="1.25.0", suffix="-alpine"
+/// - "16-alpine" → version_part="16", suffix="-alpine"
+/// - "v1.0.0" → version_part="1.0.0", suffix=""
+/// - "1.25" → version_part="1.25", suffix=""
+fn parse_docker_tag(tag: &str) -> Option<ParsedDockerTag> {
+    // Strip v/V prefix
+    let tag = tag.strip_prefix('v').unwrap_or(tag);
+    let tag = tag.strip_prefix('V').unwrap_or(tag);
+
+    if tag.is_empty() {
+        return None;
+    }
+
+    // First char must be a digit
+    if !tag.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+
+    // Find where the numeric version part ends
+    // Version part: digits and dots
+    let version_end = tag
+        .find(|c: char| !c.is_ascii_digit() && c != '.')
+        .unwrap_or(tag.len());
+
+    let version_part = &tag[..version_end];
+    let suffix = &tag[version_end..];
+
+    if version_part.is_empty() {
+        return None;
+    }
+
+    // Normalize to semver
+    let normalized = normalize_to_semver(version_part)?;
+    let semver = Version::parse(&normalized).ok()?;
+
+    Some(ParsedDockerTag {
+        version_part: version_part.to_string(),
+        suffix: suffix.to_string(),
+        semver,
+    })
+}
+
+/// Normalize a version string to X.Y.Z format
+fn normalize_to_semver(version: &str) -> Option<String> {
+    let parts: Vec<&str> = version.split('.').collect();
+    match parts.as_slice() {
+        [major] => {
+            let _: u64 = major.parse().ok()?;
+            Some(format!("{}.0.0", major))
+        }
+        [major, minor] => {
+            let _: u64 = major.parse().ok()?;
+            let _: u64 = minor.parse().ok()?;
+            Some(format!("{}.{}.0", major, minor))
+        }
+        [major, minor, patch] => {
+            let _: u64 = major.parse().ok()?;
+            let _: u64 = minor.parse().ok()?;
+            let _: u64 = patch.parse().ok()?;
+            Some(format!("{}.{}.{}", major, minor, patch))
+        }
+        _ => None,
+    }
+}
+
+/// Count how many version parts were specified
+fn count_version_parts(version: &str) -> usize {
+    version.split('.').count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("1.25.0-alpine", "1.25.0", "-alpine")]
+    #[case("16-alpine", "16", "-alpine")]
+    #[case("v1.0.0", "1.0.0", "")]
+    #[case("1.25", "1.25", "")]
+    #[case("15", "15", "")]
+    #[case("1.25.0-alpine3.18", "1.25.0", "-alpine3.18")]
+    fn parse_docker_tag_extracts_version_and_suffix(
+        #[case] tag: &str,
+        #[case] expected_version: &str,
+        #[case] expected_suffix: &str,
+    ) {
+        let parsed = parse_docker_tag(tag).unwrap();
+        assert_eq!(parsed.version_part, expected_version);
+        assert_eq!(parsed.suffix, expected_suffix);
+    }
+
+    #[rstest]
+    #[case("latest")]
+    #[case("alpine")]
+    #[case("stable")]
+    #[case("")]
+    fn parse_docker_tag_returns_none_for_non_numeric(#[case] tag: &str) {
+        assert!(parse_docker_tag(tag).is_none());
+    }
+
+    #[rstest]
+    // Same version → Latest
+    #[case("1.25", "1.25", CompareResult::Latest)]
+    #[case("1.25.0", "1.25.0", CompareResult::Latest)]
+    #[case("15", "15", CompareResult::Latest)]
+    // Outdated
+    #[case("1.25", "1.27", CompareResult::Outdated)]
+    #[case("15", "17", CompareResult::Outdated)]
+    #[case("1.25.0", "1.27.0", CompareResult::Outdated)]
+    // Newer
+    #[case("1.27", "1.25", CompareResult::Newer)]
+    #[case("17", "15", CompareResult::Newer)]
+    // Suffixed tags - only numeric part compared
+    #[case("1.25-alpine", "1.27-alpine", CompareResult::Outdated)]
+    #[case("1.27-alpine", "1.27-alpine", CompareResult::Latest)]
+    // v prefix
+    #[case("v1.0.0", "v2.0.0", CompareResult::Outdated)]
+    // Partial version matching
+    #[case("15", "17", CompareResult::Outdated)]
+    #[case("15", "15", CompareResult::Latest)]
+    // Invalid
+    #[case("latest", "1.25", CompareResult::Invalid)]
+    #[case("1.25", "latest", CompareResult::Invalid)]
+    fn compare_to_latest_returns_expected(
+        #[case] current: &str,
+        #[case] latest: &str,
+        #[case] expected: CompareResult,
+    ) {
+        let matcher = DockerVersionMatcher;
+        assert_eq!(matcher.compare_to_latest(current, latest), expected);
+    }
+
+    #[test]
+    fn resolve_latest_returns_same_suffix_version_when_available() {
+        let matcher = DockerVersionMatcher;
+        let all_versions = vec![
+            "1.25".to_string(),
+            "1.25-alpine".to_string(),
+            "1.27".to_string(),
+            "1.27-alpine".to_string(),
+        ];
+        assert_eq!(
+            matcher.resolve_latest("1.25-alpine", "1.27", &all_versions),
+            "1.27-alpine"
+        );
+    }
+
+    #[test]
+    fn resolve_latest_falls_back_to_latest_when_no_same_suffix() {
+        let matcher = DockerVersionMatcher;
+        let all_versions = vec![
+            "1.25".to_string(),
+            "1.25-alpine".to_string(),
+            "1.27".to_string(),
+        ];
+        // No "1.27-alpine" exists
+        assert_eq!(
+            matcher.resolve_latest("1.25-alpine", "1.27", &all_versions),
+            "1.27"
+        );
+    }
+
+    #[test]
+    fn resolve_latest_returns_latest_when_no_suffix() {
+        let matcher = DockerVersionMatcher;
+        let all_versions = vec!["1.25".to_string(), "1.27".to_string()];
+        assert_eq!(
+            matcher.resolve_latest("1.25", "1.27", &all_versions),
+            "1.27"
+        );
+    }
+
+    #[test]
+    fn resolve_latest_falls_back_when_same_suffix_is_not_newer() {
+        let matcher = DockerVersionMatcher;
+        let all_versions = vec!["1.27".to_string(), "1.27-alpine".to_string()];
+        // Current is already at the max for that suffix
+        assert_eq!(
+            matcher.resolve_latest("1.27-alpine", "1.27", &all_versions),
+            "1.27"
+        );
+    }
+
+    #[test]
+    fn version_exists_checks_exact_match() {
+        let matcher = DockerVersionMatcher;
+        let versions = vec!["1.25".to_string(), "1.25-alpine".to_string()];
+        assert!(matcher.version_exists("1.25", &versions));
+        assert!(matcher.version_exists("1.25-alpine", &versions));
+        assert!(!matcher.version_exists("1.26", &versions));
+    }
+}

--- a/src/version/matchers/docker.rs
+++ b/src/version/matchers/docker.rs
@@ -8,7 +8,7 @@ use semver::Version;
 use tracing::warn;
 
 use crate::parser::types::RegistryType;
-use crate::version::matcher::VersionMatcher;
+use crate::version::matcher::{BumpTargets, VersionMatcher};
 use crate::version::semver::CompareResult;
 
 pub struct DockerVersionMatcher;
@@ -55,6 +55,64 @@ impl VersionMatcher for DockerVersionMatcher {
                 std::cmp::Ordering::Less => CompareResult::Outdated,
                 std::cmp::Ordering::Greater => CompareResult::Newer,
             },
+        }
+    }
+
+    fn calculate_bump_targets(
+        &self,
+        current_version: &str,
+        available_versions: &[String],
+    ) -> BumpTargets {
+        let Some(current_parsed) = parse_docker_tag(current_version) else {
+            return BumpTargets::default();
+        };
+
+        let current_suffix = &current_parsed.suffix;
+
+        // Collect versions with the same suffix, parsed into semver
+        let same_suffix_versions: Vec<(&str, Version)> = available_versions
+            .iter()
+            .filter_map(|v| {
+                let parsed = parse_docker_tag(v)?;
+                if parsed.suffix == *current_suffix {
+                    Some((v.as_str(), parsed.semver))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        // patch: same major.minor, higher patch
+        let patch = same_suffix_versions
+            .iter()
+            .filter(|(_, sv)| {
+                sv.major == current_parsed.semver.major
+                    && sv.minor == current_parsed.semver.minor
+                    && *sv > current_parsed.semver
+            })
+            .max_by(|(_, a), (_, b)| a.cmp(b))
+            .map(|(tag, _)| tag.to_string());
+
+        // minor: same major, higher minor
+        let minor = same_suffix_versions
+            .iter()
+            .filter(|(_, sv)| {
+                sv.major == current_parsed.semver.major && sv.minor > current_parsed.semver.minor
+            })
+            .max_by(|(_, a), (_, b)| a.cmp(b))
+            .map(|(tag, _)| tag.to_string());
+
+        // major: higher major
+        let major = same_suffix_versions
+            .iter()
+            .filter(|(_, sv)| sv.major > current_parsed.semver.major)
+            .max_by(|(_, a), (_, b)| a.cmp(b))
+            .map(|(tag, _)| tag.to_string());
+
+        BumpTargets {
+            patch,
+            minor,
+            major,
         }
     }
 
@@ -299,5 +357,42 @@ mod tests {
         assert!(matcher.version_exists("1.25", &versions));
         assert!(matcher.version_exists("1.25-alpine", &versions));
         assert!(!matcher.version_exists("1.26", &versions));
+    }
+
+    #[test]
+    fn calculate_bump_targets_returns_same_suffix_versions_when_suffixed() {
+        let matcher = DockerVersionMatcher;
+        let versions = vec![
+            "1.25".to_string(),
+            "1.25-alpine".to_string(),
+            "1.27".to_string(),
+            "1.27-alpine".to_string(),
+            "2.0".to_string(),
+            "2.0-alpine".to_string(),
+        ];
+        let targets = matcher.calculate_bump_targets("1.25-alpine", &versions);
+        assert_eq!(targets.patch, None);
+        assert_eq!(targets.minor, Some("1.27-alpine".to_string()));
+        assert_eq!(targets.major, Some("2.0-alpine".to_string()));
+    }
+
+    #[test]
+    fn calculate_bump_targets_returns_versions_when_no_suffix() {
+        let matcher = DockerVersionMatcher;
+        let versions = vec!["1.25".to_string(), "1.27".to_string(), "2.0".to_string()];
+        let targets = matcher.calculate_bump_targets("1.25", &versions);
+        assert_eq!(targets.patch, None);
+        assert_eq!(targets.minor, Some("1.27".to_string()));
+        assert_eq!(targets.major, Some("2.0".to_string()));
+    }
+
+    #[test]
+    fn calculate_bump_targets_returns_default_when_invalid_tag() {
+        let matcher = DockerVersionMatcher;
+        let versions = vec!["1.25".to_string(), "1.27".to_string()];
+        let targets = matcher.calculate_bump_targets("latest", &versions);
+        assert_eq!(targets.patch, None);
+        assert_eq!(targets.minor, None);
+        assert_eq!(targets.major, None);
     }
 }

--- a/src/version/matchers/mod.rs
+++ b/src/version/matchers/mod.rs
@@ -1,6 +1,7 @@
 //! Registry-specific version matchers
 
 pub mod crates;
+pub mod docker;
 pub mod github_actions;
 pub mod go;
 pub mod jsr;
@@ -9,6 +10,7 @@ pub mod pnpm;
 pub mod pypi;
 
 pub use crates::CratesVersionMatcher;
+pub use docker::DockerVersionMatcher;
 pub use github_actions::GitHubActionsMatcher;
 pub use go::GoVersionMatcher;
 pub use jsr::JsrVersionMatcher;

--- a/src/version/registries/docker.rs
+++ b/src/version/registries/docker.rs
@@ -1,0 +1,451 @@
+//! Docker Registry HTTP API V2 client
+//!
+//! Supports fetching tags from Docker Hub and ghcr.io.
+//! Dispatches to the appropriate registry based on the package name prefix.
+
+use crate::parser::types::RegistryType;
+use crate::version::error::RegistryError;
+use crate::version::registry::Registry;
+use crate::version::types::PackageVersions;
+use semver::Version;
+use serde::Deserialize;
+use tracing::warn;
+
+/// Docker Hub registry URL
+const DOCKER_HUB_REGISTRY_URL: &str = "https://registry-1.docker.io";
+/// Docker Hub auth URL
+const DOCKER_HUB_AUTH_URL: &str = "https://auth.docker.io/token";
+/// Docker Hub service name
+const DOCKER_HUB_SERVICE: &str = "registry.docker.io";
+
+/// ghcr.io registry URL
+const GHCR_REGISTRY_URL: &str = "https://ghcr.io";
+/// ghcr.io auth URL
+const GHCR_AUTH_URL: &str = "https://ghcr.io/token";
+/// ghcr.io service name
+const GHCR_SERVICE: &str = "ghcr.io";
+
+/// Token response from the auth endpoint
+#[derive(Debug, Deserialize)]
+struct TokenResponse {
+    token: String,
+}
+
+/// Tag list response from the registry
+#[derive(Debug, Deserialize)]
+struct TagListResponse {
+    tags: Option<Vec<String>>,
+}
+
+/// Registry implementation for Docker (Docker Hub + ghcr.io)
+pub struct DockerRegistry {
+    client: reqwest::Client,
+    /// Override base URLs for testing
+    docker_hub_registry_url: String,
+    docker_hub_auth_url: String,
+    ghcr_registry_url: String,
+    ghcr_auth_url: String,
+}
+
+impl DockerRegistry {
+    /// Create a new DockerRegistry with custom URLs (for testing)
+    pub fn new(
+        docker_hub_registry_url: &str,
+        docker_hub_auth_url: &str,
+        ghcr_registry_url: &str,
+        ghcr_auth_url: &str,
+    ) -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .user_agent("version-lsp")
+                .build()
+                .expect("Failed to create HTTP client"),
+            docker_hub_registry_url: docker_hub_registry_url.to_string(),
+            docker_hub_auth_url: docker_hub_auth_url.to_string(),
+            ghcr_registry_url: ghcr_registry_url.to_string(),
+            ghcr_auth_url: ghcr_auth_url.to_string(),
+        }
+    }
+
+    /// Fetch a token for the given repository
+    async fn fetch_token(
+        &self,
+        auth_url: &str,
+        service: &str,
+        repository: &str,
+    ) -> Result<String, RegistryError> {
+        let url = format!(
+            "{}?service={}&scope=repository:{}:pull",
+            auth_url, service, repository
+        );
+
+        let response = self.client.get(&url).send().await?;
+        let status = response.status();
+
+        if !status.is_success() {
+            warn!("Docker auth failed with status {}: {}", status, url);
+            return Err(RegistryError::InvalidResponse(format!(
+                "Auth failed: {}",
+                status
+            )));
+        }
+
+        let token_resp: TokenResponse = response.json().await.map_err(|e| {
+            warn!("Failed to parse token response: {}", e);
+            RegistryError::InvalidResponse(e.to_string())
+        })?;
+
+        Ok(token_resp.token)
+    }
+
+    /// Fetch tag list for the given repository
+    async fn fetch_tags(
+        &self,
+        registry_url: &str,
+        repository: &str,
+        token: &str,
+    ) -> Result<Vec<String>, RegistryError> {
+        let url = format!("{}/v2/{}/tags/list", registry_url, repository);
+
+        let response = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let status = response.status();
+
+        if status == reqwest::StatusCode::NOT_FOUND {
+            return Err(RegistryError::NotFound(repository.to_string()));
+        }
+
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse().ok());
+            return Err(RegistryError::RateLimited {
+                retry_after_secs: retry_after,
+            });
+        }
+
+        if !status.is_success() {
+            warn!("Docker registry returned status {}: {}", status, url);
+            return Err(RegistryError::InvalidResponse(format!(
+                "Unexpected status: {}",
+                status
+            )));
+        }
+
+        let tag_list: TagListResponse = response.json().await.map_err(|e| {
+            warn!("Failed to parse tag list response: {}", e);
+            RegistryError::InvalidResponse(e.to_string())
+        })?;
+
+        Ok(tag_list.tags.unwrap_or_default())
+    }
+
+    /// Resolve which registry config and API repository name to use
+    fn resolve_registry(&self, package_name: &str) -> (&str, &str, &str, String) {
+        if let Some(repo) = package_name.strip_prefix("ghcr.io/") {
+            (
+                &self.ghcr_auth_url,
+                &self.ghcr_registry_url,
+                GHCR_SERVICE,
+                repo.to_string(),
+            )
+        } else {
+            (
+                &self.docker_hub_auth_url,
+                &self.docker_hub_registry_url,
+                DOCKER_HUB_SERVICE,
+                package_name.to_string(),
+            )
+        }
+    }
+}
+
+impl Default for DockerRegistry {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::builder()
+                .user_agent("version-lsp")
+                .build()
+                .expect("Failed to create HTTP client"),
+            docker_hub_registry_url: DOCKER_HUB_REGISTRY_URL.to_string(),
+            docker_hub_auth_url: DOCKER_HUB_AUTH_URL.to_string(),
+            ghcr_registry_url: GHCR_REGISTRY_URL.to_string(),
+            ghcr_auth_url: GHCR_AUTH_URL.to_string(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl Registry for DockerRegistry {
+    fn registry_type(&self) -> RegistryType {
+        RegistryType::Docker
+    }
+
+    async fn fetch_all_versions(
+        &self,
+        package_name: &str,
+    ) -> Result<PackageVersions, RegistryError> {
+        let (auth_url, registry_url, service, repository) = self.resolve_registry(package_name);
+
+        // Step 1: Get token
+        let token = self.fetch_token(auth_url, service, &repository).await?;
+
+        // Step 2: Fetch tags
+        let tags = self.fetch_tags(registry_url, &repository, &token).await?;
+
+        // Step 3: Filter and sort tags
+        let versions = filter_and_sort_tags(tags);
+
+        Ok(PackageVersions::new(versions))
+    }
+}
+
+/// Filter tags to only include version-like tags and sort them.
+///
+/// - Only keeps tags starting with a digit (filters out "latest", "alpine", "stable", etc.)
+/// - Sorts by semver version (ascending: oldest first, newest last)
+/// - Within the same version, suffixless tags come last
+fn filter_and_sort_tags(tags: Vec<String>) -> Vec<String> {
+    let mut versioned: Vec<(String, Version, String)> = tags
+        .into_iter()
+        .filter_map(|tag| {
+            // Strip v/V prefix for initial digit check
+            let stripped = tag
+                .strip_prefix('v')
+                .or_else(|| tag.strip_prefix('V'))
+                .unwrap_or(&tag);
+
+            // Must start with a digit
+            if !stripped.starts_with(|c: char| c.is_ascii_digit()) {
+                return None;
+            }
+
+            // Extract version part (digits and dots)
+            let version_end = stripped
+                .find(|c: char| !c.is_ascii_digit() && c != '.')
+                .unwrap_or(stripped.len());
+
+            let version_part = &stripped[..version_end];
+            let suffix = stripped[version_end..].to_string();
+
+            // Normalize to semver
+            let parts: Vec<&str> = version_part.split('.').collect();
+            let normalized = match parts.len() {
+                1 => format!("{}.0.0", parts[0]),
+                2 => format!("{}.{}.0", parts[0], parts[1]),
+                3 => format!("{}.{}.{}", parts[0], parts[1], parts[2]),
+                _ => return None,
+            };
+
+            let semver = Version::parse(&normalized).ok()?;
+            Some((tag, semver, suffix))
+        })
+        .collect();
+
+    // Sort by version ascending, then suffixless last within same version
+    versioned.sort_by(|(_, ver_a, suffix_a), (_, ver_b, suffix_b)| {
+        ver_a.cmp(ver_b).then_with(|| {
+            // Within same version: suffixed before suffixless
+            match (suffix_a.is_empty(), suffix_b.is_empty()) {
+                (true, false) => std::cmp::Ordering::Greater,
+                (false, true) => std::cmp::Ordering::Less,
+                _ => suffix_a.cmp(suffix_b),
+            }
+        })
+    });
+
+    versioned.into_iter().map(|(tag, _, _)| tag).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mockito::Server;
+    use rstest::rstest;
+
+    #[tokio::test]
+    async fn fetch_all_versions_returns_filtered_sorted_tags_for_docker_hub() {
+        let mut auth_server = Server::new_async().await;
+        let mut registry_server = Server::new_async().await;
+
+        let auth_mock = auth_server
+            .mock("GET", "/token")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("service".into(), "registry.docker.io".into()),
+                mockito::Matcher::UrlEncoded(
+                    "scope".into(),
+                    "repository:library/nginx:pull".into(),
+                ),
+            ]))
+            .with_status(200)
+            .with_body(r#"{"token": "test-token"}"#)
+            .create_async()
+            .await;
+
+        let tags_mock = registry_server
+            .mock("GET", "/v2/library/nginx/tags/list")
+            .match_header("authorization", "Bearer test-token")
+            .with_status(200)
+            .with_body(r#"{"tags": ["latest", "1.25", "1.25-alpine", "1.27", "1.27-alpine", "alpine", "stable"]}"#)
+            .create_async()
+            .await;
+
+        let auth_url = format!("{}/token", auth_server.url());
+        let registry = DockerRegistry::new(&registry_server.url(), &auth_url, "", "");
+
+        let result = registry.fetch_all_versions("library/nginx").await.unwrap();
+
+        auth_mock.assert_async().await;
+        tags_mock.assert_async().await;
+
+        // Should only include versioned tags, sorted ascending
+        assert_eq!(
+            result.versions,
+            vec![
+                "1.25-alpine".to_string(),
+                "1.25".to_string(),
+                "1.27-alpine".to_string(),
+                "1.27".to_string(),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_all_versions_returns_not_found_for_nonexistent_image() {
+        let mut auth_server = Server::new_async().await;
+        let mut registry_server = Server::new_async().await;
+
+        let auth_mock = auth_server
+            .mock("GET", "/token")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"{"token": "test-token"}"#)
+            .create_async()
+            .await;
+
+        let tags_mock = registry_server
+            .mock("GET", "/v2/library/nonexistent/tags/list")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let auth_url = format!("{}/token", auth_server.url());
+        let registry = DockerRegistry::new(&registry_server.url(), &auth_url, "", "");
+
+        let result = registry.fetch_all_versions("library/nonexistent").await;
+
+        auth_mock.assert_async().await;
+        tags_mock.assert_async().await;
+        assert!(matches!(result, Err(RegistryError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn fetch_all_versions_returns_rate_limited_for_429() {
+        let mut auth_server = Server::new_async().await;
+        let mut registry_server = Server::new_async().await;
+
+        let auth_mock = auth_server
+            .mock("GET", "/token")
+            .match_query(mockito::Matcher::Any)
+            .with_status(200)
+            .with_body(r#"{"token": "test-token"}"#)
+            .create_async()
+            .await;
+
+        let tags_mock = registry_server
+            .mock("GET", "/v2/library/nginx/tags/list")
+            .with_status(429)
+            .with_header("retry-after", "60")
+            .create_async()
+            .await;
+
+        let auth_url = format!("{}/token", auth_server.url());
+        let registry = DockerRegistry::new(&registry_server.url(), &auth_url, "", "");
+
+        let result = registry.fetch_all_versions("library/nginx").await;
+
+        auth_mock.assert_async().await;
+        tags_mock.assert_async().await;
+        assert!(matches!(
+            result,
+            Err(RegistryError::RateLimited {
+                retry_after_secs: Some(60)
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_all_versions_dispatches_ghcr_correctly() {
+        let mut ghcr_auth_server = Server::new_async().await;
+        let mut ghcr_registry_server = Server::new_async().await;
+
+        let auth_mock = ghcr_auth_server
+            .mock("GET", "/token")
+            .match_query(mockito::Matcher::AllOf(vec![
+                mockito::Matcher::UrlEncoded("service".into(), "ghcr.io".into()),
+                mockito::Matcher::UrlEncoded("scope".into(), "repository:owner/repo:pull".into()),
+            ]))
+            .with_status(200)
+            .with_body(r#"{"token": "ghcr-token"}"#)
+            .create_async()
+            .await;
+
+        let tags_mock = ghcr_registry_server
+            .mock("GET", "/v2/owner/repo/tags/list")
+            .match_header("authorization", "Bearer ghcr-token")
+            .with_status(200)
+            .with_body(r#"{"tags": ["v1.0.0", "v2.0.0", "latest"]}"#)
+            .create_async()
+            .await;
+
+        let ghcr_auth_url = format!("{}/token", ghcr_auth_server.url());
+        let registry = DockerRegistry::new("", "", &ghcr_registry_server.url(), &ghcr_auth_url);
+
+        let result = registry
+            .fetch_all_versions("ghcr.io/owner/repo")
+            .await
+            .unwrap();
+
+        auth_mock.assert_async().await;
+        tags_mock.assert_async().await;
+
+        assert_eq!(
+            result.versions,
+            vec!["v1.0.0".to_string(), "v2.0.0".to_string()]
+        );
+    }
+
+    #[rstest]
+    #[case(
+        vec!["latest", "1.25", "1.25-alpine", "1.27", "1.27-alpine", "alpine"],
+        vec!["1.25-alpine", "1.25", "1.27-alpine", "1.27"]
+    )]
+    #[case(
+        vec!["v1.0.0", "v2.0.0", "latest", "stable"],
+        vec!["v1.0.0", "v2.0.0"]
+    )]
+    #[case(
+        vec!["15", "16", "17", "latest", "alpine"],
+        vec!["15", "16", "17"]
+    )]
+    #[case(
+        vec![],
+        vec![]
+    )]
+    fn filter_and_sort_tags_returns_expected(
+        #[case] input: Vec<&str>,
+        #[case] expected: Vec<&str>,
+    ) {
+        let tags: Vec<String> = input.into_iter().map(|s| s.to_string()).collect();
+        let result = filter_and_sort_tags(tags);
+        let expected: Vec<String> = expected.into_iter().map(|s| s.to_string()).collect();
+        assert_eq!(result, expected);
+    }
+}

--- a/src/version/registries/docker.rs
+++ b/src/version/registries/docker.rs
@@ -5,6 +5,7 @@
 
 use crate::parser::types::RegistryType;
 use crate::version::error::RegistryError;
+use crate::version::matchers::docker::parse_docker_tag;
 use crate::version::registry::Registry;
 use crate::version::types::PackageVersions;
 use semver::Version;
@@ -216,36 +217,8 @@ fn filter_and_sort_tags(tags: Vec<String>) -> Vec<String> {
     let mut versioned: Vec<(String, Version, String)> = tags
         .into_iter()
         .filter_map(|tag| {
-            // Strip v/V prefix for initial digit check
-            let stripped = tag
-                .strip_prefix('v')
-                .or_else(|| tag.strip_prefix('V'))
-                .unwrap_or(&tag);
-
-            // Must start with a digit
-            if !stripped.starts_with(|c: char| c.is_ascii_digit()) {
-                return None;
-            }
-
-            // Extract version part (digits and dots)
-            let version_end = stripped
-                .find(|c: char| !c.is_ascii_digit() && c != '.')
-                .unwrap_or(stripped.len());
-
-            let version_part = &stripped[..version_end];
-            let suffix = stripped[version_end..].to_string();
-
-            // Normalize to semver
-            let parts: Vec<&str> = version_part.split('.').collect();
-            let normalized = match parts.len() {
-                1 => format!("{}.0.0", parts[0]),
-                2 => format!("{}.{}.0", parts[0], parts[1]),
-                3 => format!("{}.{}.{}", parts[0], parts[1], parts[2]),
-                _ => return None,
-            };
-
-            let semver = Version::parse(&normalized).ok()?;
-            Some((tag, semver, suffix))
+            let parsed = parse_docker_tag(&tag)?;
+            Some((tag, parsed.semver, parsed.suffix))
         })
         .collect();
 

--- a/src/version/registries/mod.rs
+++ b/src/version/registries/mod.rs
@@ -1,6 +1,7 @@
 //! Registry implementations for fetching package versions
 
 pub mod crates_io;
+pub mod docker;
 pub mod github;
 pub mod go_proxy;
 pub mod jsr;
@@ -8,6 +9,7 @@ pub mod npm;
 pub mod pypi;
 
 pub use crates_io::CratesIoRegistry;
+pub use docker::DockerRegistry;
 pub use github::GitHubRegistry;
 pub use go_proxy::GoProxyRegistry;
 pub use jsr::JsrRegistry;

--- a/tests/e2e_docker.rs
+++ b/tests/e2e_docker.rs
@@ -1,0 +1,247 @@
+//! Docker (compose.yaml) E2E tests
+
+mod helper;
+
+use std::collections::HashMap;
+
+use tower::Service;
+use tower_lsp::LspService;
+use tower_lsp::lsp_types::*;
+
+use helper::{
+    MockRegistry, create_did_open_notification, create_initialize_request,
+    create_initialized_notification, create_test_cache, create_test_resolver,
+    spawn_notification_collector, wait_for_notification,
+};
+use version_lsp::lsp::backend::Backend;
+use version_lsp::lsp::resolver::PackageResolver;
+use version_lsp::parser::types::RegistryType;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publishes_outdated_version_warning() {
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::Docker,
+        &[(
+            "library/nginx",
+            vec!["1.25-alpine", "1.25", "1.27-alpine", "1.27"],
+        )],
+    );
+
+    let registry = MockRegistry::new(RegistryType::Docker).with_versions(
+        "library/nginx",
+        vec!["1.25-alpine", "1.25", "1.27-alpine", "1.27"],
+    );
+
+    let resolvers: HashMap<RegistryType, PackageResolver> = HashMap::from([(
+        RegistryType::Docker,
+        create_test_resolver(RegistryType::Docker, registry),
+    )]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let compose_yaml = r#"services:
+  web:
+    image: nginx:1.25
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/compose.yaml",
+            compose_yaml,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert_eq!(params.diagnostics.len(), 1);
+    assert_eq!(
+        params.diagnostics[0].severity,
+        Some(DiagnosticSeverity::WARNING)
+    );
+    assert_eq!(
+        params.diagnostics[0].message,
+        "Update available: 1.25 -> 1.27"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn no_diagnostics_for_latest_version() {
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::Docker,
+        &[("library/nginx", vec!["1.25", "1.27"])],
+    );
+
+    let registry = MockRegistry::new(RegistryType::Docker)
+        .with_versions("library/nginx", vec!["1.25", "1.27"]);
+
+    let resolvers: HashMap<RegistryType, PackageResolver> = HashMap::from([(
+        RegistryType::Docker,
+        create_test_resolver(RegistryType::Docker, registry),
+    )]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let compose_yaml = r#"services:
+  web:
+    image: nginx:1.27
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/compose.yaml",
+            compose_yaml,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert!(params.diagnostics.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publishes_error_for_nonexistent_tag() {
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::Docker,
+        &[("library/nginx", vec!["1.25", "1.27"])],
+    );
+
+    let registry = MockRegistry::new(RegistryType::Docker)
+        .with_versions("library/nginx", vec!["1.25", "1.27"]);
+
+    let resolvers: HashMap<RegistryType, PackageResolver> = HashMap::from([(
+        RegistryType::Docker,
+        create_test_resolver(RegistryType::Docker, registry),
+    )]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let compose_yaml = r#"services:
+  web:
+    image: nginx:999.0
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/compose.yaml",
+            compose_yaml,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert_eq!(params.diagnostics.len(), 1);
+    assert_eq!(
+        params.diagnostics[0].severity,
+        Some(DiagnosticSeverity::ERROR)
+    );
+    assert_eq!(
+        params.diagnostics[0].message,
+        "Version 999.0 not found in registry"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn handles_suffixed_tag_comparison() {
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::Docker,
+        &[(
+            "library/nginx",
+            vec!["1.25-alpine", "1.25", "1.27-alpine", "1.27"],
+        )],
+    );
+
+    let registry = MockRegistry::new(RegistryType::Docker).with_versions(
+        "library/nginx",
+        vec!["1.25-alpine", "1.25", "1.27-alpine", "1.27"],
+    );
+
+    let resolvers: HashMap<RegistryType, PackageResolver> = HashMap::from([(
+        RegistryType::Docker,
+        create_test_resolver(RegistryType::Docker, registry),
+    )]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let compose_yaml = r#"services:
+  web:
+    image: nginx:1.25-alpine
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/compose.yaml",
+            compose_yaml,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert_eq!(params.diagnostics.len(), 1);
+    assert_eq!(
+        params.diagnostics[0].severity,
+        Some(DiagnosticSeverity::WARNING)
+    );
+    // Should suggest 1.27-alpine (same suffix available)
+    assert_eq!(
+        params.diagnostics[0].message,
+        "Update available: 1.25-alpine -> 1.27-alpine"
+    );
+}

--- a/tests/helper/registry.rs
+++ b/tests/helper/registry.rs
@@ -8,6 +8,7 @@ use tempfile::TempDir;
 
 use version_lsp::lsp::resolver::PackageResolver;
 use version_lsp::parser::cargo_toml::CargoTomlParser;
+use version_lsp::parser::compose::ComposeParser;
 use version_lsp::parser::deno_json::DenoJsonParser;
 use version_lsp::parser::github_actions::GitHubActionsParser;
 use version_lsp::parser::go_mod::GoModParser;
@@ -19,8 +20,8 @@ use version_lsp::version::cache::Cache;
 use version_lsp::version::checker::VersionStorer;
 use version_lsp::version::error::RegistryError;
 use version_lsp::version::matchers::{
-    CratesVersionMatcher, GitHubActionsMatcher, GoVersionMatcher, JsrVersionMatcher,
-    NpmVersionMatcher, PnpmCatalogMatcher, PypiVersionMatcher,
+    CratesVersionMatcher, DockerVersionMatcher, GitHubActionsMatcher, GoVersionMatcher,
+    JsrVersionMatcher, NpmVersionMatcher, PnpmCatalogMatcher, PypiVersionMatcher,
 };
 use version_lsp::version::registry::Registry;
 use version_lsp::version::types::PackageVersions;
@@ -104,6 +105,11 @@ pub fn create_test_resolver(
         RegistryType::PyPI => PackageResolver::new(
             Arc::new(PyprojectTomlParser::new()),
             Arc::new(PypiVersionMatcher),
+            Arc::new(mock_registry),
+        ),
+        RegistryType::Docker => PackageResolver::new(
+            Arc::new(ComposeParser::new()),
+            Arc::new(DockerVersionMatcher),
             Arc::new(mock_registry),
         ),
     }


### PR DESCRIPTION
## Summary

- Add version checking for container image tags in `compose.yaml` / `docker-compose.yaml` files
- Support Docker Hub (official and user images) and ghcr.io public images via Docker Registry HTTP API V2
- Implement suffix-aware tag comparison (e.g., `nginx:1.25-alpine` → `1.27-alpine`) through a new `resolve_latest` method on the `VersionMatcher` trait

## Changes

### New files
| File | Purpose |
|------|---------|
| `src/parser/compose.rs` | tree-sitter YAML parser extracting `services.*.image` fields |
| `src/version/matchers/docker.rs` | Tag version matcher with suffix support (`-alpine`, `-slim`, etc.) |
| `src/version/registries/docker.rs` | Docker Registry HTTP API V2 client (token auth → tag list) |
| `tests/e2e_docker.rs` | 4 E2E tests (outdated, latest, not-found, suffixed tags) |

### Modified files
| File | Change |
|------|--------|
| `src/parser/types.rs` | `RegistryType::Docker` variant, `detect_parser_type()` for compose files |
| `src/version/matcher.rs` | `resolve_latest()` default method (returns `latest_version` unchanged) |
| `src/version/checker.rs` | Call `resolve_latest()` before `compare_to_latest()` |
| `src/config.rs` | `docker` field in `RegistriesConfig` |
| `src/lsp/backend.rs` | `Docker` arm in `is_registry_enabled()` |
| `src/lsp/resolver.rs` | Docker `PackageResolver` in `create_default_resolvers()` |
| `src/parser/mod.rs`, `src/version/matchers/mod.rs`, `src/version/registries/mod.rs` | Module registration |
| `tests/helper/registry.rs` | `Docker` case in `create_test_resolver()` |

### Skipped cases
Tagless images, `latest` tag, digest references (`@sha256:...`), variable expansions (`${VAR}`), and unsupported registries (mcr.microsoft.com, quay.io, etc.).

## Test plan
- [x] 647 tests pass (`cargo nextest run`)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt -- --check` — clean
- [ ] Manual test with a real `compose.yaml` in an editor

🤖 Generated with [Claude Code](https://claude.com/claude-code)