### PR TITLE
fix: position JSR version range on the version token

### DIFF
--- a/src/parser/deno_json.rs
+++ b/src/parser/deno_json.rs
@@ -47,24 +47,42 @@ impl Parser for DenoJsonParser {
     }
 }
 
-impl DenoJsonParser {
-    /// Parse JSR specifier format: jsr:@scope/package@version
-    /// Returns (package_name, version)
-    fn parse_jsr_specifier(value: &str) -> Option<(String, String)> {
-        let rest = value.strip_prefix("jsr:")?;
+/// Parsed JSR specifier (`jsr:@scope/pkg@version`).
+///
+/// `version_offset_in_value` is `Some(idx)` when an explicit version is
+/// present and points at the version token's start inside the raw value,
+/// so code-action edits can target only the version range. For specifiers
+/// without a version, it is `None` and `version` is the sentinel `"latest"`.
+struct JsrSpecifier {
+    package_name: String,
+    version: String,
+    version_offset_in_value: Option<usize>,
+}
 
-        // @scope/package@version format
-        // Find the @ that separates package from version (after the scope's @)
+impl DenoJsonParser {
+    /// Parse JSR specifier format: `jsr:@scope/package@version`.
+    fn parse_jsr_specifier(value: &str) -> Option<JsrSpecifier> {
+        let rest = value.strip_prefix("jsr:")?;
+        let prefix_len = "jsr:".len();
+
         let slash_pos = rest.find('/')?;
         let after_slash = &rest[slash_pos + 1..];
 
         if let Some(at_pos) = after_slash.find('@') {
             let package_name = &rest[..slash_pos + 1 + at_pos];
             let version = &after_slash[at_pos + 1..];
-            Some((package_name.to_string(), version.to_string()))
+            let version_offset_in_value = prefix_len + slash_pos + 1 + at_pos + 1;
+            Some(JsrSpecifier {
+                package_name: package_name.to_string(),
+                version: version.to_string(),
+                version_offset_in_value: Some(version_offset_in_value),
+            })
         } else {
-            // No version specified
-            Some((rest.to_string(), "latest".to_string()))
+            Some(JsrSpecifier {
+                package_name: rest.to_string(),
+                version: "latest".to_string(),
+                version_offset_in_value: None,
+            })
         }
     }
 
@@ -127,23 +145,32 @@ impl DenoJsonParser {
             let raw_value = self.get_string_value(value_node, content);
 
             // Only process jsr: prefixed entries
-            let Some((package_name, version)) = Self::parse_jsr_specifier(&raw_value) else {
+            let Some(specifier) = Self::parse_jsr_specifier(&raw_value) else {
                 continue;
             };
 
             let start_point = value_node.start_position();
-            let start_offset = value_node.start_byte();
-            let end_offset = value_node.end_byte();
+            let value_start = value_node.start_byte();
+            let value_end = value_node.end_byte();
 
-            // Version position: start after "jsr:@scope/package@" to get just the version
-            // For now, we'll use the full value node position
-            let version_start_offset = start_offset + 1; // Skip opening quote
-            let version_end_offset = end_offset - 1; // Skip closing quote
-            let version_column = start_point.column + 1; // Skip opening quote
+            // +1 to skip the opening quote on the value.
+            let (version_start_offset, version_end_offset, version_column) =
+                if let Some(offset) = specifier.version_offset_in_value {
+                    let start = value_start + 1 + offset;
+                    (
+                        start,
+                        start + specifier.version.len(),
+                        start_point.column + 1 + offset,
+                    )
+                } else {
+                    // No explicit version: span the whole inner value so
+                    // diagnostics still highlight the specifier.
+                    (value_start + 1, value_end - 1, start_point.column + 1)
+                };
 
             results.push(PackageInfo {
-                name: package_name,
-                version,
+                name: specifier.package_name,
+                version: specifier.version,
                 commit_hash: None,
                 registry_type: RegistryType::Jsr,
                 start_offset: version_start_offset,
@@ -186,10 +213,10 @@ mod tests {
                 version: "^1.0.1".to_string(),
                 commit_hash: None,
                 registry_type: RegistryType::Jsr,
-                start_offset: 36,
+                start_offset: 51,
                 end_offset: 57,
                 line: 2,
-                column: 19,
+                column: 34,
                 extra_info: None,
             }
         );
@@ -213,10 +240,10 @@ mod tests {
                     version: "^1.0.1".to_string(),
                     commit_hash: None,
                     registry_type: RegistryType::Jsr,
-                    start_offset: 36,
+                    start_offset: 51,
                     end_offset: 57,
                     line: 2,
-                    column: 19,
+                    column: 34,
                     extra_info: None,
                 },
                 PackageInfo {
@@ -224,10 +251,10 @@ mod tests {
                     version: "1.0.0".to_string(),
                     commit_hash: None,
                     registry_type: RegistryType::Jsr,
-                    start_offset: 78,
+                    start_offset: 92,
                     end_offset: 97,
                     line: 3,
-                    column: 18,
+                    column: 32,
                     extra_info: None,
                 },
             ]
@@ -251,10 +278,10 @@ mod tests {
                 version: "^1.0.1".to_string(),
                 commit_hash: None,
                 registry_type: RegistryType::Jsr,
-                start_offset: 36,
+                start_offset: 51,
                 end_offset: 57,
                 line: 2,
-                column: 19,
+                column: 34,
                 extra_info: None,
             }]
         );
@@ -303,5 +330,27 @@ mod tests {
 }"#;
         let result = parser.parse(content).unwrap();
         assert!(result.is_empty());
+    }
+
+    /// Regression: the parser used to point start_offset/column at the
+    /// opening quote of the value, so any code-action edit at this range
+    /// would overwrite the `jsr:` prefix instead of just the version.
+    /// The parser-reported edit range must isolate the version token.
+    #[test]
+    fn jsr_specifier_offsets_isolate_version_token() {
+        let parser = DenoJsonParser::new();
+        let content = r#"{
+  "imports": {
+    "@luca/flag": "jsr:@luca/flag@^1.0.1"
+  }
+}"#;
+        let info = parser
+            .parse(content)
+            .unwrap()
+            .into_iter()
+            .next()
+            .expect("jsr import parsed");
+
+        assert_eq!(&content[info.start_offset..info.end_offset], info.version,);
     }
 }


### PR DESCRIPTION
## Summary

For a `jsr:<name>@<version>` import in `deno.json` / `deno.jsonc`, the parser used to emit `start_offset` / `column` pointing at the opening quote of the value (i.e. at `"jsr:`). Two consequences:

1. `find_at_position` missed the cursor when it sat on the version range — features that key off cursor position would not trigger.
2. Any code-action edit applied at the parser-reported range would overwrite the `jsr:` prefix instead of just the version.

The parser now computes the version offset inside the value (`jsr:` prefix length + scope + slash + name + `@`) and reports the edit range exactly over the version token. Imports without an explicit version (`jsr:@scope/name`) still span the whole inner value so diagnostics keep highlighting the specifier.

## Test plan

- [x] Existing case-table tests in `deno_json.rs` updated to the new offsets
- [x] New focused regression test `jsr_specifier_offsets_isolate_version_token` asserts the invariant `content[info.start_offset..info.end_offset] == info.version`
- [x] `cargo test --lib parser::deno_json`
- [x] `cargo fmt -- --check` and `cargo clippy --all-targets`

## Why this is a separate PR

Surfaced while implementing the "Pin to locked version" code action (#121) — without this fix, the deno-lock pin action would overwrite the `jsr:` prefix. Pulling it out so it can be reviewed on its own terms; the pin-action PR is stacked on top.