### PR TITLE
feat(config): add per-registry URL overrides for private mirrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,24 @@ lspconfig.version_lsp.setup({
         pnpmCatalog = { enabled = true },
         jsr = { enabled = true },
         docker = { enabled = true },
+
+        -- Optional URL overrides (e.g. for private mirrors). When a
+        -- registry's `url` is unset the default public registry is used.
+        -- Credentials embedded in URLs are redacted from logs.
+        --
+        -- pypi = { url = "https://pypi.internal.example.com" },
+        -- npm = { url = "https://npm.internal.example.com" },
+        -- crates = { url = "https://crates.internal.example.com/api/v1/crates" },
+        -- goProxy = { url = "https://goproxy.internal.example.com" },
+        -- github = { url = "https://github.example.com/api/v3" },
+        -- jsr = { url = "https://jsr.internal.example.com" },
+        -- pnpmCatalog = { url = "https://npm.internal.example.com" },
+        -- docker = {
+        --   dockerHubRegistryUrl = "https://hub.internal.example.com",
+        --   dockerHubAuthUrl = "https://hub.internal.example.com/token",
+        --   ghcrRegistryUrl = "https://ghcr.internal.example.com",
+        --   ghcrAuthUrl = "https://ghcr.internal.example.com/token",
+        -- },
       },
       ignorePrerelease = true,  -- Ignore prerelease versions (default: true)
     },
@@ -170,14 +188,33 @@ lspconfig.version_lsp.setup({
 | -------------------------------- | ------- | ---------- | ---------------------------------------------------------- |
 | `cache.refreshInterval`          | number  | `86400000` | Cache refresh interval in milliseconds (default: 24 hours) |
 | `registries.npm.enabled`         | boolean | `true`     | Enable npm registry checks                                 |
+| `registries.npm.url`             | string  | unset      | Override npm registry base URL                             |
 | `registries.crates.enabled`      | boolean | `true`     | Enable crates.io registry checks                           |
+| `registries.crates.url`          | string  | unset      | Override crates.io API base URL                            |
 | `registries.goProxy.enabled`     | boolean | `true`     | Enable Go Proxy registry checks                            |
+| `registries.goProxy.url`         | string  | unset      | Override Go Proxy base URL                                 |
 | `registries.pypi.enabled`        | boolean | `true`     | Enable PyPI registry checks                                |
+| `registries.pypi.url`            | string  | unset      | Override PyPI base URL                                     |
 | `registries.github.enabled`      | boolean | `true`     | Enable GitHub Releases checks                              |
+| `registries.github.url`          | string  | unset      | Override GitHub API base URL (Enterprise). Falls back to `GITHUB_API_BASE_URL` env var when unset |
 | `registries.pnpmCatalog.enabled` | boolean | `true`     | Enable pnpm catalog checks                                 |
+| `registries.pnpmCatalog.url`     | string  | unset      | Override pnpm catalog registry URL (defaults to `npm.url`) |
 | `registries.jsr.enabled`         | boolean | `true`     | Enable JSR registry checks                                 |
+| `registries.jsr.url`             | string  | unset      | Override JSR base URL                                      |
 | `registries.docker.enabled`      | boolean | `true`     | Enable Docker Hub / ghcr.io checks                         |
+| `registries.docker.dockerHubRegistryUrl` | string | unset | Override Docker Hub registry URL                          |
+| `registries.docker.dockerHubAuthUrl`     | string | unset | Override Docker Hub auth URL                              |
+| `registries.docker.ghcrRegistryUrl`      | string | unset | Override ghcr.io registry URL                             |
+| `registries.docker.ghcrAuthUrl`          | string | unset | Override ghcr.io auth URL                                 |
 | `ignorePrerelease`               | boolean | `true`     | Ignore prerelease versions (alpha, beta, rc, etc.)         |
+
+URL overrides apply on the next configuration push from your editor (delivered
+via `workspace/configuration` after `initialized`). Subsequent fetches use the
+new URL; cached versions are not invalidated.
+
+For private indexes that need credentials, embed them in the URL
+(`https://user:token@private.example.com/`). User/password are redacted from
+log output. There is currently no separate auth field.
 
 ## Data Storage
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -363,6 +363,12 @@ pub trait Registry: Send + Sync {
 | JsrRegistry     | `jsr.io/api/scopes/{scope}/packages/{pkg}`             | JSR scoped packages                       |
 | DockerRegistry  | Docker Hub: `registry-1.docker.io`, ghcr.io: `ghcr.io` | Token auth, tag filtering/sorting         |
 
+All registry base URLs are overridable via `registries.<name>.url` in the LSP
+configuration (Docker exposes four URLs: `dockerHubRegistryUrl`,
+`dockerHubAuthUrl`, `ghcrRegistryUrl`, `ghcrAuthUrl`). When the user pushes a
+new configuration the resolver map in `Backend` is rebuilt; subsequent fetches
+hit the new URLs. The cache is not invalidated.
+
 ---
 
 ## Configuration
@@ -383,19 +389,30 @@ pub trait Registry: Send + Sync {
       "refreshInterval": 86400000
     },
     "registries": {
-      "npm": { "enabled": true },
-      "crates": { "enabled": true },
-      "goProxy": { "enabled": true },
-      "github": { "enabled": true },
-      "pypi": { "enabled": true },
-      "pnpmCatalog": { "enabled": true },
-      "jsr": { "enabled": true },
-      "docker": { "enabled": true }
+      "npm": { "enabled": true, "url": null },
+      "crates": { "enabled": true, "url": null },
+      "goProxy": { "enabled": true, "url": null },
+      "github": { "enabled": true, "url": null },
+      "pypi": { "enabled": true, "url": null },
+      "pnpmCatalog": { "enabled": true, "url": null },
+      "jsr": { "enabled": true, "url": null },
+      "docker": {
+        "enabled": true,
+        "dockerHubRegistryUrl": null,
+        "dockerHubAuthUrl": null,
+        "ghcrRegistryUrl": null,
+        "ghcrAuthUrl": null
+      }
     },
     "ignorePrerelease": true
   }
 }
 ```
+
+When a `url` is `null` (or absent), the registry uses its hardcoded default.
+URL-embedded credentials (`https://user:token@host/path`) are redacted from
+log output via a custom `Debug` impl on `RegistryConfig` and
+`DockerRegistryConfig`.
 
 ### Constants
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,5 @@
 use serde::Deserialize;
+use std::fmt;
 use std::path::PathBuf;
 
 // =============================================================================
@@ -63,20 +64,111 @@ pub struct RegistriesConfig {
     pub pnpm_catalog: RegistryConfig,
     pub jsr: RegistryConfig,
     pub pypi: RegistryConfig,
-    pub docker: RegistryConfig,
+    pub docker: DockerRegistryConfig,
 }
 
-/// Individual registry configuration
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+/// Individual registry configuration with optional URL override
+#[derive(Clone, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct RegistryConfig {
     pub enabled: bool,
+    /// Override the registry base URL. When `None`, the registry's hardcoded default is used.
+    pub url: Option<String>,
 }
 
 impl Default for RegistryConfig {
     fn default() -> Self {
-        Self { enabled: true }
+        Self {
+            enabled: true,
+            url: None,
+        }
     }
+}
+
+impl fmt::Debug for RegistryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RegistryConfig")
+            .field("enabled", &self.enabled)
+            .field("url", &self.url.as_deref().map(redact_userinfo))
+            .finish()
+    }
+}
+
+/// Docker registry configuration. Docker dispatches to either Docker Hub or
+/// ghcr.io based on the image name prefix, so each backend has its own
+/// optional registry and auth URL override.
+#[derive(Clone, Deserialize, PartialEq)]
+#[serde(default, rename_all = "camelCase")]
+pub struct DockerRegistryConfig {
+    pub enabled: bool,
+    pub docker_hub_registry_url: Option<String>,
+    pub docker_hub_auth_url: Option<String>,
+    pub ghcr_registry_url: Option<String>,
+    pub ghcr_auth_url: Option<String>,
+}
+
+impl Default for DockerRegistryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            docker_hub_registry_url: None,
+            docker_hub_auth_url: None,
+            ghcr_registry_url: None,
+            ghcr_auth_url: None,
+        }
+    }
+}
+
+impl fmt::Debug for DockerRegistryConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DockerRegistryConfig")
+            .field("enabled", &self.enabled)
+            .field(
+                "docker_hub_registry_url",
+                &self.docker_hub_registry_url.as_deref().map(redact_userinfo),
+            )
+            .field(
+                "docker_hub_auth_url",
+                &self.docker_hub_auth_url.as_deref().map(redact_userinfo),
+            )
+            .field(
+                "ghcr_registry_url",
+                &self.ghcr_registry_url.as_deref().map(redact_userinfo),
+            )
+            .field(
+                "ghcr_auth_url",
+                &self.ghcr_auth_url.as_deref().map(redact_userinfo),
+            )
+            .finish()
+    }
+}
+
+/// Replace `user:password@` userinfo in a URL with `***@` so credentials are
+/// not leaked through `Debug` formatting (e.g. `tracing::info!("{:?}", config)`).
+///
+/// Non-URL strings or URLs without userinfo are returned unchanged. This is a
+/// best-effort textual transform; it does not parse the URL.
+fn redact_userinfo(url: &str) -> String {
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let after_scheme = scheme_end + 3;
+    let rest = &url[after_scheme..];
+
+    // Userinfo, if present, ends at the first '@' before the next '/', '?' or '#'.
+    let host_terminator = rest.find(['/', '?', '#']).unwrap_or(rest.len());
+    let authority = &rest[..host_terminator];
+
+    let Some(at_idx) = authority.find('@') else {
+        return url.to_string();
+    };
+
+    let mut redacted = String::with_capacity(url.len());
+    redacted.push_str(&url[..after_scheme]);
+    redacted.push_str("***");
+    redacted.push_str(&authority[at_idx..]);
+    redacted.push_str(&rest[host_terminator..]);
+    redacted
 }
 
 /// Returns the path to the data directory for version-lsp.
@@ -149,18 +241,165 @@ mod tests {
                     refresh_interval: 5000
                 },
                 registries: RegistriesConfig {
-                    npm: RegistryConfig { enabled: false },
-                    crates: RegistryConfig { enabled: true },
-                    go_proxy: RegistryConfig { enabled: false },
-                    github: RegistryConfig { enabled: true },
-                    pnpm_catalog: RegistryConfig { enabled: false },
-                    jsr: RegistryConfig { enabled: false },
-                    pypi: RegistryConfig { enabled: true },
-                    docker: RegistryConfig { enabled: true },
+                    npm: RegistryConfig {
+                        enabled: false,
+                        url: None
+                    },
+                    crates: RegistryConfig {
+                        enabled: true,
+                        url: None
+                    },
+                    go_proxy: RegistryConfig {
+                        enabled: false,
+                        url: None
+                    },
+                    github: RegistryConfig {
+                        enabled: true,
+                        url: None
+                    },
+                    pnpm_catalog: RegistryConfig {
+                        enabled: false,
+                        url: None
+                    },
+                    jsr: RegistryConfig {
+                        enabled: false,
+                        url: None
+                    },
+                    pypi: RegistryConfig {
+                        enabled: true,
+                        url: None
+                    },
+                    docker: DockerRegistryConfig::default(),
                 },
                 ignore_prerelease: true,
             }
         );
+    }
+
+    #[test]
+    fn registry_config_parses_url_override() {
+        let result = serde_json::from_value::<LspConfig>(json!({
+            "registries": {
+                "pypi": { "url": "https://private.example.com/simple" },
+                "npm": { "enabled": false, "url": "https://npm.internal/" }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            result.registries.pypi,
+            RegistryConfig {
+                enabled: true,
+                url: Some("https://private.example.com/simple".to_string())
+            }
+        );
+        assert_eq!(
+            result.registries.npm,
+            RegistryConfig {
+                enabled: false,
+                url: Some("https://npm.internal/".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn docker_registry_config_parses_all_url_overrides() {
+        let result = serde_json::from_value::<LspConfig>(json!({
+            "registries": {
+                "docker": {
+                    "dockerHubRegistryUrl": "https://hub.example.com",
+                    "dockerHubAuthUrl": "https://auth.example.com/token",
+                    "ghcrRegistryUrl": "https://ghcr.internal",
+                    "ghcrAuthUrl": "https://ghcr.internal/token"
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            result.registries.docker,
+            DockerRegistryConfig {
+                enabled: true,
+                docker_hub_registry_url: Some("https://hub.example.com".to_string()),
+                docker_hub_auth_url: Some("https://auth.example.com/token".to_string()),
+                ghcr_registry_url: Some("https://ghcr.internal".to_string()),
+                ghcr_auth_url: Some("https://ghcr.internal/token".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn registry_config_debug_redacts_userinfo() {
+        let config = RegistryConfig {
+            enabled: true,
+            url: Some("https://user:secret@private.example.com/simple".to_string()),
+        };
+
+        let debug = format!("{:?}", config);
+
+        assert!(!debug.contains("secret"), "password leaked in: {}", debug);
+        assert!(!debug.contains("user:"), "username leaked in: {}", debug);
+        assert!(debug.contains("***@private.example.com"));
+    }
+
+    #[test]
+    fn docker_registry_config_debug_redacts_userinfo() {
+        let config = DockerRegistryConfig {
+            enabled: true,
+            docker_hub_registry_url: Some("https://u:p@hub.example.com".to_string()),
+            docker_hub_auth_url: None,
+            ghcr_registry_url: Some("https://x:y@ghcr.internal/".to_string()),
+            ghcr_auth_url: None,
+        };
+
+        let debug = format!("{:?}", config);
+
+        assert!(!debug.contains(":p@"), "password leaked in: {}", debug);
+        assert!(!debug.contains(":y@"), "password leaked in: {}", debug);
+        assert!(debug.contains("***@hub.example.com"));
+        assert!(debug.contains("***@ghcr.internal"));
+    }
+
+    #[test]
+    fn redact_userinfo_passes_through_urls_without_credentials() {
+        assert_eq!(
+            redact_userinfo("https://pypi.org/simple"),
+            "https://pypi.org/simple"
+        );
+        assert_eq!(
+            redact_userinfo("https://example.com/path?q=1#frag"),
+            "https://example.com/path?q=1#frag"
+        );
+    }
+
+    #[test]
+    fn redact_userinfo_redacts_user_and_password() {
+        assert_eq!(
+            redact_userinfo("https://alice:hunter2@example.com/path"),
+            "https://***@example.com/path"
+        );
+    }
+
+    #[test]
+    fn redact_userinfo_redacts_user_only() {
+        assert_eq!(
+            redact_userinfo("https://token@example.com/"),
+            "https://***@example.com/"
+        );
+    }
+
+    #[test]
+    fn redact_userinfo_does_not_treat_at_in_path_as_userinfo() {
+        // The '@' is in the path, not the authority.
+        assert_eq!(
+            redact_userinfo("https://example.com/foo@bar"),
+            "https://example.com/foo@bar"
+        );
+    }
+
+    #[test]
+    fn redact_userinfo_returns_input_when_not_a_url() {
+        assert_eq!(redact_userinfo("not-a-url"), "not-a-url");
     }
 
     #[test]

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -17,7 +17,6 @@ use crate::lsp::resolver::{PackageResolver, create_resolvers};
 use crate::parser::types::{PackageInfo, RegistryType, detect_parser_type};
 use crate::version::cache::Cache;
 use crate::version::checker::VersionStorer;
-use crate::version::registries::github::GitHubRegistry;
 use crate::version::registry::Registry;
 
 /// Cached parsed packages for a document
@@ -476,22 +475,31 @@ impl<S: VersionStorer> LanguageServer for Backend<S> {
             package.name, package.version
         );
 
-        let matcher = {
+        let (matcher, sha_fetcher) = {
             let resolvers = self.resolvers.read().expect("resolvers lock poisoned");
             let Some(resolver) = resolvers.get(&registry_type) else {
                 debug!("No resolver for registry type {:?}", registry_type);
                 return Ok(None);
             };
-            resolver.matcher().clone()
+            (resolver.matcher().clone(), resolver.sha_fetcher().cloned())
         };
 
         // For GitHub Actions with commit hash, use async function to fetch SHA
         let mut actions = if package.registry_type == RegistryType::GitHubActions
             && package.commit_hash.is_some()
         {
-            let sha_fetcher = GitHubRegistry::default();
-            generate_upgrade_code_actions_with_sha(&**storer, package, uri, &sha_fetcher, &*matcher)
-                .await
+            let Some(sha_fetcher) = sha_fetcher else {
+                debug!("No SHA fetcher for registry type {:?}", registry_type);
+                return Ok(None);
+            };
+            generate_upgrade_code_actions_with_sha(
+                &**storer,
+                package,
+                uri,
+                &*sha_fetcher,
+                &*matcher,
+            )
+            .await
         } else {
             generate_upgrade_code_actions(&**storer, package, uri, &*matcher)
         };

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -13,7 +13,7 @@ use crate::lsp::code_action::{
 };
 use crate::lsp::diagnostics::generate_diagnostics;
 use crate::lsp::refresh::{fetch_missing_packages, refresh_packages};
-use crate::lsp::resolver::{PackageResolver, create_default_resolvers};
+use crate::lsp::resolver::{PackageResolver, create_resolvers};
 use crate::parser::types::{PackageInfo, RegistryType, detect_parser_type};
 use crate::version::cache::Cache;
 use crate::version::checker::VersionStorer;
@@ -29,7 +29,7 @@ pub struct Backend<S: VersionStorer> {
     client: Client,
     storer: Option<Arc<S>>,
     config: Arc<RwLock<LspConfig>>,
-    resolvers: HashMap<RegistryType, PackageResolver>,
+    resolvers: Arc<RwLock<HashMap<RegistryType, PackageResolver>>>,
     documents: Arc<RwLock<HashMap<Url, DocumentCache>>>,
 }
 
@@ -37,12 +37,12 @@ impl Backend<Cache> {
     pub fn new(client: Client) -> Self {
         let config = LspConfig::default();
         let storer = Self::initialize_storer(&config);
-        let resolvers = create_default_resolvers();
+        let resolvers = create_resolvers(&config);
         Self {
             client,
             storer,
             config: Arc::new(RwLock::new(config)),
-            resolvers,
+            resolvers: Arc::new(RwLock::new(resolvers)),
             documents: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -85,7 +85,7 @@ impl<S: VersionStorer> Backend<S> {
             client,
             storer: Some(storer),
             config: Arc::new(RwLock::new(LspConfig::default())),
-            resolvers,
+            resolvers: Arc::new(RwLock::new(resolvers)),
             documents: Arc::new(RwLock::new(HashMap::new())),
         }
     }
@@ -93,8 +93,9 @@ impl<S: VersionStorer> Backend<S> {
     /// Parse document and cache packages
     fn cache_document(&self, uri: &Url, content: &str) {
         let uri_str = uri.as_str();
+        let resolvers = self.resolvers.read().expect("resolvers lock poisoned");
         let packages = detect_parser_type(uri_str)
-            .and_then(|registry_type| self.resolvers.get(&registry_type))
+            .and_then(|registry_type| resolvers.get(&registry_type))
             .map(|resolver| {
                 resolver
                     .parser()
@@ -103,6 +104,7 @@ impl<S: VersionStorer> Backend<S> {
                     .unwrap_or_default()
             })
             .unwrap_or_default();
+        drop(resolvers);
 
         let mut docs = self.documents.write().expect("documents lock poisoned");
         docs.insert(uri.clone(), DocumentCache { packages });
@@ -127,6 +129,7 @@ impl<S: VersionStorer> Backend<S> {
     fn spawn_fetch_configuration(&self) {
         let client = self.client.clone();
         let config = self.config.clone();
+        let resolvers = self.resolvers.clone();
 
         tokio::spawn(async move {
             let items = vec![ConfigurationItem {
@@ -152,8 +155,18 @@ impl<S: VersionStorer> Backend<S> {
                             }
                         };
                         info!("Configuration updated: {:?}", new_config);
+
+                        // Rebuild resolvers from the new config so URL
+                        // overrides take effect on subsequent fetches.
+                        let new_resolvers = create_resolvers(&new_config);
+
                         let mut cfg = config.write().expect("config lock poisoned");
                         *cfg = new_config;
+                        drop(cfg);
+
+                        let mut res = resolvers.write().expect("resolvers lock poisoned");
+                        *res = new_resolvers;
+                        debug!("Resolvers rebuilt with new configuration");
                     }
                 }
                 Err(e) => {
@@ -184,9 +197,12 @@ impl<S: VersionStorer> Backend<S> {
             return;
         };
 
-        // Extract registries from resolvers for background task
+        // Snapshot registries from the current resolvers so the spawned task
+        // doesn't need to hold the lock or share `self`.
         let registries: HashMap<RegistryType, Arc<dyn Registry>> = self
             .resolvers
+            .read()
+            .expect("resolvers lock poisoned")
             .iter()
             .map(|(k, v)| (*k, v.registry().clone()))
             .collect();
@@ -244,9 +260,19 @@ impl<S: VersionStorer> Backend<S> {
             return;
         }
 
-        let Some(resolver) = self.resolvers.get(&registry_type) else {
-            debug!("No resolver found for registry type: {:?}", registry_type);
-            return;
+        // Snapshot parser/matcher/registry from the resolver under a brief
+        // read lock so we don't hold the lock across awaits or `tokio::spawn`.
+        let (parser, matcher, registry) = {
+            let resolvers = self.resolvers.read().expect("resolvers lock poisoned");
+            let Some(resolver) = resolvers.get(&registry_type) else {
+                debug!("No resolver found for registry type: {:?}", registry_type);
+                return;
+            };
+            (
+                resolver.parser().clone(),
+                resolver.matcher().clone(),
+                resolver.registry().clone(),
+            )
         };
 
         let Some(storer) = &self.storer else {
@@ -260,19 +286,13 @@ impl<S: VersionStorer> Backend<S> {
         };
 
         // Parse document to get packages (needed for on-demand fetch)
-        let packages = resolver
-            .parser()
+        let packages = parser
             .parse(&content)
             .inspect_err(|e| warn!("Failed to parse {}: {}", uri_str, e))
             .unwrap_or_default();
         debug!("Parsed {} packages: {:?}", packages.len(), packages);
 
-        let diagnostics = generate_diagnostics(
-            &**resolver.parser(),
-            &**resolver.matcher(),
-            &**storer,
-            &content,
-        );
+        let diagnostics = generate_diagnostics(&*parser, &*matcher, &**storer, &content);
 
         self.client
             .log_message(
@@ -295,11 +315,8 @@ impl<S: VersionStorer> Backend<S> {
                 "Spawning background task to fetch {} packages",
                 packages.len()
             );
-            let registry = resolver.registry().clone();
             let storer = storer.clone();
             let client = self.client.clone();
-            let parser = resolver.parser().clone();
-            let matcher = resolver.matcher().clone();
 
             tokio::spawn(async move {
                 debug!("Background task started for fetching packages");
@@ -459,9 +476,13 @@ impl<S: VersionStorer> LanguageServer for Backend<S> {
             package.name, package.version
         );
 
-        let Some(resolver) = self.resolvers.get(&registry_type) else {
-            debug!("No resolver for registry type {:?}", registry_type);
-            return Ok(None);
+        let matcher = {
+            let resolvers = self.resolvers.read().expect("resolvers lock poisoned");
+            let Some(resolver) = resolvers.get(&registry_type) else {
+                debug!("No resolver for registry type {:?}", registry_type);
+                return Ok(None);
+            };
+            resolver.matcher().clone()
         };
 
         // For GitHub Actions with commit hash, use async function to fetch SHA
@@ -469,16 +490,10 @@ impl<S: VersionStorer> LanguageServer for Backend<S> {
             && package.commit_hash.is_some()
         {
             let sha_fetcher = GitHubRegistry::default();
-            generate_upgrade_code_actions_with_sha(
-                &**storer,
-                package,
-                uri,
-                &sha_fetcher,
-                &**resolver.matcher(),
-            )
-            .await
+            generate_upgrade_code_actions_with_sha(&**storer, package, uri, &sha_fetcher, &*matcher)
+                .await
         } else {
-            generate_upgrade_code_actions(&**storer, package, uri, &**resolver.matcher())
+            generate_upgrade_code_actions(&**storer, package, uri, &*matcher)
         };
 
         // Append constraint actions based on registry type

--- a/src/lsp/code_action/upgrade.rs
+++ b/src/lsp/code_action/upgrade.rs
@@ -95,7 +95,7 @@ pub fn generate_upgrade_code_actions<S: VersionStorer>(
 /// When the package has a commit hash (GitHub Actions), this function will fetch
 /// the commit SHA for each bump target and generate code actions that replace
 /// the hash (and optionally the comment) with the new SHA and version.
-pub async fn generate_upgrade_code_actions_with_sha<S: VersionStorer, F: TagShaFetcher>(
+pub async fn generate_upgrade_code_actions_with_sha<S: VersionStorer, F: TagShaFetcher + ?Sized>(
     storer: &S,
     package: &PackageInfo,
     uri: &Url,
@@ -159,7 +159,7 @@ pub async fn generate_upgrade_code_actions_with_sha<S: VersionStorer, F: TagShaF
 ///
 /// For hash-only packages, we don't know the current semantic version,
 /// so we just offer to update to the latest available version.
-async fn generate_hash_only_actions<S: VersionStorer, F: TagShaFetcher>(
+async fn generate_hash_only_actions<S: VersionStorer, F: TagShaFetcher + ?Sized>(
     storer: &S,
     package: &PackageInfo,
     uri: &Url,

--- a/src/lsp/resolver.rs
+++ b/src/lsp/resolver.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::config::{LspConfig, RegistryConfig};
 use crate::parser::cargo_toml::CargoTomlParser;
 use crate::parser::compose::ComposeParser;
 use crate::parser::deno_json::DenoJsonParser;
@@ -73,17 +74,25 @@ impl PackageResolver {
     }
 }
 
-/// Create the default set of package resolvers for all supported registry types
-pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
+/// Build the set of package resolvers for all supported registry types using
+/// URL overrides from the supplied configuration. Any registry whose
+/// [`RegistryConfig::url`] is `None` uses its hardcoded default URL.
+pub fn create_resolvers(config: &LspConfig) -> HashMap<RegistryType, PackageResolver> {
+    let registries = &config.registries;
     let mut resolvers = HashMap::new();
-    let npm_restistry = NpmRegistry::default();
+
+    // Single shared NpmRegistry for both Npm and PnpmCatalog. They map to
+    // separate config keys so a user could override them independently, but
+    // sharing the instance when both URLs match avoids duplicate HTTP clients.
+    // We accept the rare case where they differ by building two clients.
+    let npm_registry = npm_registry_from(&registries.npm);
 
     resolvers.insert(
         RegistryType::GitHubActions,
         PackageResolver::new(
             Arc::new(GitHubActionsParser::new()),
             Arc::new(GitHubActionsMatcher),
-            Arc::new(GitHubRegistry::default()),
+            Arc::new(github_registry_from(&registries.github)),
         ),
     );
 
@@ -92,7 +101,7 @@ pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
         PackageResolver::new(
             Arc::new(PackageJsonParser::new()),
             Arc::new(NpmVersionMatcher),
-            Arc::new(npm_restistry.clone()),
+            Arc::new(npm_registry.clone()),
         ),
     );
 
@@ -101,7 +110,7 @@ pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
         PackageResolver::new(
             Arc::new(CargoTomlParser::new()),
             Arc::new(CratesVersionMatcher),
-            Arc::new(CratesIoRegistry::default()),
+            Arc::new(crates_registry_from(&registries.crates)),
         ),
     );
 
@@ -110,16 +119,24 @@ pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
         PackageResolver::new(
             Arc::new(GoModParser::new()),
             Arc::new(GoVersionMatcher),
-            Arc::new(GoProxyRegistry::default()),
+            Arc::new(go_proxy_registry_from(&registries.go_proxy)),
         ),
     );
+
+    // pnpm catalog reuses the npm registry. If the user overrides the
+    // pnpmCatalog URL independently of npm, build a second NpmRegistry.
+    let pnpm_registry = if registries.pnpm_catalog.url == registries.npm.url {
+        npm_registry
+    } else {
+        npm_registry_from(&registries.pnpm_catalog)
+    };
 
     resolvers.insert(
         RegistryType::PnpmCatalog,
         PackageResolver::new(
             Arc::new(PnpmWorkspaceParser),
             Arc::new(PnpmCatalogMatcher),
-            Arc::new(npm_restistry),
+            Arc::new(pnpm_registry),
         ),
     );
 
@@ -128,7 +145,7 @@ pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
         PackageResolver::new(
             Arc::new(DenoJsonParser::new()),
             Arc::new(JsrVersionMatcher),
-            Arc::new(JsrRegistry::default()),
+            Arc::new(jsr_registry_from(&registries.jsr)),
         ),
     );
 
@@ -137,7 +154,7 @@ pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
         PackageResolver::new(
             Arc::new(PyprojectTomlParser::new()),
             Arc::new(PypiVersionMatcher),
-            Arc::new(PypiRegistry::default()),
+            Arc::new(pypi_registry_from(&registries.pypi)),
         ),
     );
 
@@ -146,9 +163,216 @@ pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
         PackageResolver::new(
             Arc::new(ComposeParser::new()),
             Arc::new(DockerVersionMatcher),
-            Arc::new(DockerRegistry::default()),
+            Arc::new(DockerRegistry::with_overrides(
+                registries.docker.docker_hub_registry_url.as_deref(),
+                registries.docker.docker_hub_auth_url.as_deref(),
+                registries.docker.ghcr_registry_url.as_deref(),
+                registries.docker.ghcr_auth_url.as_deref(),
+            )),
         ),
     );
 
     resolvers
+}
+
+/// Build the default set of resolvers (no URL overrides). Equivalent to
+/// `create_resolvers(&LspConfig::default())`.
+pub fn create_default_resolvers() -> HashMap<RegistryType, PackageResolver> {
+    create_resolvers(&LspConfig::default())
+}
+
+fn pypi_registry_from(cfg: &RegistryConfig) -> PypiRegistry {
+    cfg.url
+        .as_deref()
+        .map(|u| PypiRegistry::new(u.to_string()))
+        .unwrap_or_default()
+}
+
+fn npm_registry_from(cfg: &RegistryConfig) -> NpmRegistry {
+    cfg.url.as_deref().map(NpmRegistry::new).unwrap_or_default()
+}
+
+fn crates_registry_from(cfg: &RegistryConfig) -> CratesIoRegistry {
+    cfg.url
+        .as_deref()
+        .map(CratesIoRegistry::new)
+        .unwrap_or_default()
+}
+
+fn go_proxy_registry_from(cfg: &RegistryConfig) -> GoProxyRegistry {
+    cfg.url
+        .as_deref()
+        .map(GoProxyRegistry::new)
+        .unwrap_or_default()
+}
+
+fn jsr_registry_from(cfg: &RegistryConfig) -> JsrRegistry {
+    cfg.url.as_deref().map(JsrRegistry::new).unwrap_or_default()
+}
+
+/// Build a `GitHubRegistry`. LSP config takes precedence over the
+/// `GITHUB_API_BASE_URL` environment variable (which is preserved as a
+/// fallback for backward compatibility), which in turn takes precedence over
+/// the hardcoded default.
+fn github_registry_from(cfg: &RegistryConfig) -> GitHubRegistry {
+    if let Some(url) = cfg.url.as_deref() {
+        GitHubRegistry::new(url)
+    } else {
+        GitHubRegistry::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{DockerRegistryConfig, RegistriesConfig};
+
+    #[test]
+    fn create_resolvers_with_default_config_includes_all_registry_types() {
+        let resolvers = create_resolvers(&LspConfig::default());
+
+        for registry_type in [
+            RegistryType::Npm,
+            RegistryType::CratesIo,
+            RegistryType::GoProxy,
+            RegistryType::GitHubActions,
+            RegistryType::PnpmCatalog,
+            RegistryType::Jsr,
+            RegistryType::PyPI,
+            RegistryType::Docker,
+        ] {
+            assert!(
+                resolvers.contains_key(&registry_type),
+                "missing resolver for {:?}",
+                registry_type
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn create_resolvers_routes_pypi_fetches_to_overridden_url() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/pypi/requests/json")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"info":{"version":"1.0.0"},"releases":{"1.0.0":[]}}"#)
+            .create_async()
+            .await;
+
+        let mut config = LspConfig::default();
+        config.registries.pypi.url = Some(server.url());
+
+        let resolvers = create_resolvers(&config);
+        let registry = resolvers
+            .get(&RegistryType::PyPI)
+            .expect("PyPI resolver missing")
+            .registry();
+
+        let result = registry.fetch_all_versions("requests").await.unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(result.versions, vec!["1.0.0"]);
+    }
+
+    #[tokio::test]
+    async fn create_resolvers_routes_npm_fetches_to_overridden_url() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/lodash")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"versions":{"1.0.0":{}},"dist-tags":{"latest":"1.0.0"},"time":{}}"#)
+            .create_async()
+            .await;
+
+        let mut config = LspConfig::default();
+        config.registries.npm.url = Some(server.url());
+
+        let resolvers = create_resolvers(&config);
+        let registry = resolvers
+            .get(&RegistryType::Npm)
+            .expect("Npm resolver missing")
+            .registry();
+
+        let result = registry.fetch_all_versions("lodash").await.unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(result.versions, vec!["1.0.0"]);
+    }
+
+    #[tokio::test]
+    async fn create_resolvers_uses_independent_npm_and_pnpm_urls_when_different() {
+        let mut npm_server = mockito::Server::new_async().await;
+        let mut pnpm_server = mockito::Server::new_async().await;
+
+        let npm_mock = npm_server
+            .mock("GET", "/lodash")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"versions":{"4.0.0":{}},"dist-tags":{"latest":"4.0.0"},"time":{}}"#)
+            .create_async()
+            .await;
+        let pnpm_mock = pnpm_server
+            .mock("GET", "/lodash")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"versions":{"5.0.0":{}},"dist-tags":{"latest":"5.0.0"},"time":{}}"#)
+            .create_async()
+            .await;
+
+        let config = LspConfig {
+            registries: RegistriesConfig {
+                npm: RegistryConfig {
+                    enabled: true,
+                    url: Some(npm_server.url()),
+                },
+                pnpm_catalog: RegistryConfig {
+                    enabled: true,
+                    url: Some(pnpm_server.url()),
+                },
+                ..RegistriesConfig::default()
+            },
+            ..LspConfig::default()
+        };
+
+        let resolvers = create_resolvers(&config);
+
+        let npm = resolvers.get(&RegistryType::Npm).unwrap().registry();
+        let pnpm = resolvers
+            .get(&RegistryType::PnpmCatalog)
+            .unwrap()
+            .registry();
+
+        let npm_result = npm.fetch_all_versions("lodash").await.unwrap();
+        let pnpm_result = pnpm.fetch_all_versions("lodash").await.unwrap();
+
+        npm_mock.assert_async().await;
+        pnpm_mock.assert_async().await;
+        assert_eq!(npm_result.versions, vec!["4.0.0"]);
+        assert_eq!(pnpm_result.versions, vec!["5.0.0"]);
+    }
+
+    #[test]
+    fn docker_with_overrides_applies_partial_overrides_from_config() {
+        // We can't easily HTTP-test Docker here (it makes auth + tag calls in
+        // sequence and parsing is complex), so just verify the config path
+        // builds a resolver without panicking when partial overrides are set.
+        let config = LspConfig {
+            registries: RegistriesConfig {
+                docker: DockerRegistryConfig {
+                    enabled: true,
+                    docker_hub_registry_url: Some("https://hub.example.com".to_string()),
+                    docker_hub_auth_url: None,
+                    ghcr_registry_url: None,
+                    ghcr_auth_url: None,
+                },
+                ..RegistriesConfig::default()
+            },
+            ..LspConfig::default()
+        };
+
+        let resolvers = create_resolvers(&config);
+        assert!(resolvers.contains_key(&RegistryType::Docker));
+    }
 }

--- a/src/lsp/resolver.rs
+++ b/src/lsp/resolver.rs
@@ -24,7 +24,7 @@ use crate::version::matchers::{
 };
 use crate::version::registries::crates_io::CratesIoRegistry;
 use crate::version::registries::docker::DockerRegistry;
-use crate::version::registries::github::GitHubRegistry;
+use crate::version::registries::github::{GitHubRegistry, TagShaFetcher};
 use crate::version::registries::go_proxy::GoProxyRegistry;
 use crate::version::registries::jsr::JsrRegistry;
 use crate::version::registries::npm::NpmRegistry;
@@ -42,6 +42,7 @@ pub struct PackageResolver {
     parser: Arc<dyn Parser>,
     matcher: Arc<dyn VersionMatcher>,
     registry: Arc<dyn Registry>,
+    sha_fetcher: Option<Arc<dyn TagShaFetcher>>,
 }
 
 impl PackageResolver {
@@ -55,7 +56,16 @@ impl PackageResolver {
             parser,
             matcher,
             registry,
+            sha_fetcher: None,
         }
+    }
+
+    /// Attach a tag-SHA fetcher (used by GitHub Actions to resolve commit
+    /// hashes). Keeping it on the resolver ensures the configured registry URL
+    /// override is honored wherever SHA fetching happens.
+    pub fn with_sha_fetcher(mut self, sha_fetcher: Arc<dyn TagShaFetcher>) -> Self {
+        self.sha_fetcher = Some(sha_fetcher);
+        self
     }
 
     /// Get the parser for this registry type
@@ -72,6 +82,11 @@ impl PackageResolver {
     pub fn registry(&self) -> &Arc<dyn Registry> {
         &self.registry
     }
+
+    /// Get the tag-SHA fetcher, if this resolver provides one
+    pub fn sha_fetcher(&self) -> Option<&Arc<dyn TagShaFetcher>> {
+        self.sha_fetcher.as_ref()
+    }
 }
 
 /// Build the set of package resolvers for all supported registry types using
@@ -87,13 +102,19 @@ pub fn create_resolvers(config: &LspConfig) -> HashMap<RegistryType, PackageReso
     // We accept the rare case where they differ by building two clients.
     let npm_registry = npm_registry_from(&registries.npm);
 
+    // One GitHubRegistry instance serves both the version fetch (Registry) and
+    // the commit-hash → SHA fetch (TagShaFetcher) so the configured URL
+    // override is honored on both paths.
+    let github_registry = Arc::new(github_registry_from(&registries.github));
+
     resolvers.insert(
         RegistryType::GitHubActions,
         PackageResolver::new(
             Arc::new(GitHubActionsParser::new()),
             Arc::new(GitHubActionsMatcher),
-            Arc::new(github_registry_from(&registries.github)),
-        ),
+            github_registry.clone(),
+        )
+        .with_sha_fetcher(github_registry),
     );
 
     resolvers.insert(
@@ -273,6 +294,38 @@ mod tests {
 
         mock.assert_async().await;
         assert_eq!(result.versions, vec!["1.0.0"]);
+    }
+
+    #[tokio::test]
+    async fn create_resolvers_routes_github_sha_fetches_to_overridden_url() {
+        use crate::version::registries::github::TagShaFetcher;
+
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/repos/actions/checkout/tags")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"[{"name":"v4.1.7","commit":{"sha":"newsha4170000000000000000000000000000000"}}]"#)
+            .create_async()
+            .await;
+
+        let mut config = LspConfig::default();
+        config.registries.github.url = Some(server.url());
+
+        let resolvers = create_resolvers(&config);
+        let sha_fetcher = resolvers
+            .get(&RegistryType::GitHubActions)
+            .expect("GitHubActions resolver missing")
+            .sha_fetcher()
+            .expect("GitHubActions resolver missing SHA fetcher");
+
+        let sha = sha_fetcher
+            .fetch_tag_sha("actions/checkout", "v4.1.7")
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(sha, "newsha4170000000000000000000000000000000");
     }
 
     #[tokio::test]

--- a/src/lsp/resolver.rs
+++ b/src/lsp/resolver.rs
@@ -298,8 +298,6 @@ mod tests {
 
     #[tokio::test]
     async fn create_resolvers_routes_github_sha_fetches_to_overridden_url() {
-        use crate::version::registries::github::TagShaFetcher;
-
         let mut server = mockito::Server::new_async().await;
         let mock = server
             .mock("GET", "/repos/actions/checkout/tags")

--- a/src/version/registries/docker.rs
+++ b/src/version/registries/docker.rs
@@ -68,6 +68,22 @@ impl DockerRegistry {
         }
     }
 
+    /// Create a `DockerRegistry`, overriding any URL whose argument is `Some`
+    /// and falling back to the hardcoded default for any `None`.
+    pub fn with_overrides(
+        docker_hub_registry_url: Option<&str>,
+        docker_hub_auth_url: Option<&str>,
+        ghcr_registry_url: Option<&str>,
+        ghcr_auth_url: Option<&str>,
+    ) -> Self {
+        Self::new(
+            docker_hub_registry_url.unwrap_or(DOCKER_HUB_REGISTRY_URL),
+            docker_hub_auth_url.unwrap_or(DOCKER_HUB_AUTH_URL),
+            ghcr_registry_url.unwrap_or(GHCR_REGISTRY_URL),
+            ghcr_auth_url.unwrap_or(GHCR_AUTH_URL),
+        )
+    }
+
     /// Fetch a token for the given repository
     async fn fetch_token(
         &self,

--- a/tests/helper/registry.rs
+++ b/tests/helper/registry.rs
@@ -23,6 +23,7 @@ use version_lsp::version::matchers::{
     CratesVersionMatcher, DockerVersionMatcher, GitHubActionsMatcher, GoVersionMatcher,
     JsrVersionMatcher, NpmVersionMatcher, PnpmCatalogMatcher, PypiVersionMatcher,
 };
+use version_lsp::version::registries::github::GitHubRegistry;
 use version_lsp::version::registry::Registry;
 use version_lsp::version::types::PackageVersions;
 
@@ -72,11 +73,14 @@ pub fn create_test_resolver(
     mock_registry: MockRegistry,
 ) -> PackageResolver {
     match registry_type {
+        // The SHA fetcher honors GITHUB_API_BASE_URL, which the commit-hash
+        // code action tests point at their mock server.
         RegistryType::GitHubActions => PackageResolver::new(
             Arc::new(GitHubActionsParser::new()),
             Arc::new(GitHubActionsMatcher),
             Arc::new(mock_registry),
-        ),
+        )
+        .with_sha_fetcher(Arc::new(GitHubRegistry::default())),
         RegistryType::Npm => PackageResolver::new(
             Arc::new(PackageJsonParser::new()),
             Arc::new(NpmVersionMatcher),


### PR DESCRIPTION
- Add optional `url` field to `RegistryConfig` for all registries (npm, crates, goProxy, pypi, github, jsr, pnpmCatalog)

- Add `DockerRegistryConfig` with four independent URL overrides (dockerHubRegistryUrl, dockerHubAuthUrl, ghcrRegistryUrl, ghcrAuthUrl)

- Implement custom `Debug` on both config types that redacts `user:password@` userinfo from URLs to prevent credential leakage in logs

- Add `redact_userinfo()` helper with focused unit tests covering edge cases (path-only `@`, no credentials, scheme-less input)

- Rename `create_default_resolvers` → `create_resolvers(config)` so resolvers are built from live config; keep `create_default_resolvers` as a zero-arg convenience wrapper

- Wrap `Backend::resolvers` in `Arc<RwLock<...>>` and rebuild the resolver map on every `workspace/configuration` push so URL overrides take effect without restart

- Add `DockerRegistry::with_overrides()` constructor that falls back to hardcoded defaults for any `None` argument

- Switch Rust toolchain pin from `1.92.0` to `stable`

- Update README and ARCHITECTURE.md with URL override configuration reference and credential embedding guidance
