### PR TITLE
fix: Update Rust toolchain version to 1.95.0 in configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767408057,
-        "narHash": "sha256-0TD2PNTt6olOonFgcvZJcNGiU3x5cX+RMzrfWfHB9Jw=",
+        "lastModified": 1780284119,
+        "narHash": "sha256-y2wR4Mk6D/N1ID4FZa2oUMStCUxyIoRzmgOOpLzoWmo=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "294198315a13d6d130565ad08e97685df7b0d458",
+        "rev": "51390d0bfca0a68a8c337d215a4bbeddc2ca616e",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.92.0"
+channel = "1.95.0"

--- a/src/version/registries/crates_io.rs
+++ b/src/version/registries/crates_io.rs
@@ -96,7 +96,7 @@ impl Registry for CratesIoRegistry {
             })
             .collect();
 
-        versions.sort_by(|(_, a), (_, b)| a.cmp(b));
+        versions.sort_by_key(|(_, a)| *a);
 
         let versions: Vec<String> = versions.into_iter().map(|(v, _)| v).collect();
 

--- a/src/version/registries/github.rs
+++ b/src/version/registries/github.rs
@@ -132,7 +132,7 @@ impl Registry for GitHubRegistry {
             })
             .collect();
 
-        releases_with_dates.sort_by(|(_, a), (_, b)| a.cmp(b));
+        releases_with_dates.sort_by_key(|(_, a)| *a);
 
         let versions = releases_with_dates
             .into_iter()

--- a/src/version/registries/jsr.rs
+++ b/src/version/registries/jsr.rs
@@ -109,7 +109,7 @@ impl Registry for JsrRegistry {
             })
             .collect();
 
-        versions.sort_by(|(_, a), (_, b)| a.cmp(b));
+        versions.sort_by_key(|(_, a)| *a);
 
         let versions: Vec<String> = versions.into_iter().map(|(v, _)| v).collect();
 

--- a/src/version/registries/npm.rs
+++ b/src/version/registries/npm.rs
@@ -109,7 +109,7 @@ impl Registry for NpmRegistry {
             })
             .collect();
 
-        versions.sort_by(|(_, a), (_, b)| a.cmp(b));
+        versions.sort_by_key(|(_, a)| *a);
 
         let versions: Vec<String> = versions.into_iter().map(|(v, _)| v).collect();
 


### PR DESCRIPTION
## Summary

Fixes #146

Bump `rust-toolchain.toml` from `1.92.0` to `1.95.0` to fix the build failure on `main`.

The `rusqlite` 0.40.0 bump (#139) pulled in `libsqlite3-sys 0.38.0`, whose `build.rs` uses the `cfg_select!` macro. This macro was stabilized in Rust 1.95, so the pinned 1.92.0 toolchain fails with `E0658`.

## Changes

- `rust-toolchain.toml`: `channel = "1.92.0"` → `channel = "1.95.0"`
- Fixed 4 `clippy::unnecessary_sort_by` warnings (`sort_by` → `sort_by_key`) that surfaced with the new clippy in 1.95.0
  - `src/version/registries/crates_io.rs`
  - `src/version/registries/github.rs`
  - `src/version/registries/jsr.rs`
  - `src/version/registries/npm.rs`

## Verification

- `cargo build` — passes
- `cargo clippy --all-targets --all-features` — no warnings
- `cargo fmt --all -- --check` — passes
- `cargo test` — all tests pass
- Tested locally on aarch64-darwin
- `./target/release/version-lsp --version` — outputs `version-lsp 0.5.1`