### PR TITLE
feat(swift-pm): add Swift Package Manager support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ cargo clippy
 
 ## Architecture
 
-version-lsp is a Language Server Protocol implementation that checks package dependency versions across multiple registries (npm, crates.io, Go proxy, PyPI, GitHub Actions, JSR, pnpm catalogs, Docker Hub/ghcr.io).
+version-lsp is a Language Server Protocol implementation that checks package dependency versions across multiple registries (npm, crates.io, Go proxy, PyPI, GitHub Actions, JSR, pnpm catalogs, Docker Hub/ghcr.io, Swift Package Manager).
 
 詳細なアーキテクチャ（データフロー図、DB スキーマ、各コンポーネントの責務など）は [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) を参照すること。実装・設計変更時は必ずこのドキュメントを確認し、整合性を保つこと。
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2405,6 +2405,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
+name = "tree-sitter-swift"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3b98fb6bc8e6a6a10023f401aa6a1858115e849dfaf7de57dd8b8ea0f257bd9"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-toml-ng"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2539,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-json",
+ "tree-sitter-swift",
  "tree-sitter-toml-ng",
  "tree-sitter-yaml",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ tracing-appender = "0.2"
 indexmap = { version = "2.14.0", features = ["serde"] }
 futures = "0.3"
 regex = "1.12.3"
+tree-sitter-swift = "=0.7.2"
 
 [dev-dependencies]
 mockall = "0.14"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A Language Server Protocol (LSP) implementation that provides version checking d
 | `.github/workflows/*.yaml`/`.github/actions/*/*.yaml` | GitHub Releases |
 | `deno.json` / `deno.jsonc`                            | JSR             |
 | `compose.yaml` / `docker-compose.yaml`                | Docker Hub / ghcr.io |
+| `Package.swift`                                       | GitHub Releases (Swift Package Manager) |
 
 ### pnpm Catalogs
 
@@ -74,6 +75,31 @@ services:
 - Suffix-aware comparison: `nginx:1.25-alpine` suggests `1.27-alpine` when available
 - Skips `latest` tags, digest references (`@sha256:...`), and variable expansions (`${VAR}`)
 - Unsupported registries (e.g., `mcr.microsoft.com`) are ignored
+
+### Swift Package Manager
+
+Supports `Package.swift` dependencies hosted on GitHub. Versions are checked against the GitHub Releases API:
+
+```swift
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", exact: "2.50.0"),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.0")),
+        .package(url: "https://github.com/apple/swift-metrics.git", .upToNextMinor(from: "2.4.0")),
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
+        .package(url: "https://github.com/apple/swift-asn1.git", "1.0.0" ... "2.0.0"),
+    ]
+)
+```
+
+- Supported constraints: `from:`, `exact:`, `.upToNextMajor(from:)`, `.upToNextMinor(from:)`, half-open ranges (`A ..< B`), closed ranges (`A ... B`)
+- Branch and revision pins (`branch:`, `revision:`) are skipped — they have no version to compare
+- By default only `github.com` URLs are checked. Set `registries.swiftPm.url` to a private GitHub Enterprise API endpoint (e.g. `https://github.example.com/api/v3`) and the parser will also accept dependencies hosted at that URL's host. URL-embedded credentials (`https://user:token@host/`) are redacted from logs.
 
 ## Installation
 
@@ -157,6 +183,7 @@ lspconfig.version_lsp.setup({
         pnpmCatalog = { enabled = true },
         jsr = { enabled = true },
         docker = { enabled = true },
+        swiftPm = { enabled = true },
 
         -- Optional URL overrides (e.g. for private mirrors). When a
         -- registry's `url` is unset the default public registry is used.
@@ -169,6 +196,7 @@ lspconfig.version_lsp.setup({
         -- github = { url = "https://github.example.com/api/v3" },
         -- jsr = { url = "https://jsr.internal.example.com" },
         -- pnpmCatalog = { url = "https://npm.internal.example.com" },
+        -- swiftPm = { url = "https://github.example.com/api/v3" },
         -- docker = {
         --   dockerHubRegistryUrl = "https://hub.internal.example.com",
         --   dockerHubAuthUrl = "https://hub.internal.example.com/token",
@@ -206,6 +234,8 @@ lspconfig.version_lsp.setup({
 | `registries.docker.dockerHubAuthUrl`     | string | unset | Override Docker Hub auth URL                              |
 | `registries.docker.ghcrRegistryUrl`      | string | unset | Override ghcr.io registry URL                             |
 | `registries.docker.ghcrAuthUrl`          | string | unset | Override ghcr.io auth URL                                 |
+| `registries.swiftPm.enabled`     | boolean | `true`     | Enable Swift Package Manager checks                        |
+| `registries.swiftPm.url`         | string  | unset      | Override GitHub API base URL for SPM. Setting this also adds the URL's host to the parser's allow-list so dependencies hosted there are checked |
 | `ignorePrerelease`               | boolean | `true`     | Ignore prerelease versions (alpha, beta, rc, etc.)         |
 
 URL overrides apply on the next configuration push from your editor (delivered

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -21,6 +21,7 @@ version-lsp is a Language Server Protocol (LSP) implementation that provides ver
 | JSR                  | deno.json / deno.jsonc             | semver range                                  |          |
 | npm (pnpm)           | pnpm-workspace.yaml                | semver range (catalog definitions)            |          |
 | Docker Hub / ghcr.io | compose.yaml / docker-compose.yaml | Suffix-aware tag comparison                   |          |
+| GitHub Releases      | Package.swift                      | SPM (`from:`, `exact:`, `.upToNextMajor`, `.upToNextMinor`, `A ..< B`, `A ... B`) |  |
 
 ---
 
@@ -56,6 +57,7 @@ version-lsp is a Language Server Protocol (LSP) implementation that provides ver
 │  • DenoJson         │  • JsrMatcher       │  • JsrRegistry          │
 │  • PnpmWorkspace    │  • PnpmCatalog      │  (reuses NpmRegistry)   │
 │  • Compose          │  • DockerMatcher    │  • DockerRegistry       │
+│  • PackageSwift     │  • SwiftPmMatcher   │  (reuses GitHubRegistry)│
 └─────────────────────┴─────────────────────┴─────────────────────────┘
                                   │
                                   ▼
@@ -101,7 +103,8 @@ src/
 │   ├── pyproject_toml.rs   # Python pyproject.toml parser
 │   ├── deno_json.rs        # Deno deno.json/deno.jsonc parser
 │   ├── pnpm_workspace.rs   # pnpm pnpm-workspace.yaml parser
-│   └── compose.rs          # Docker compose.yaml parser
+│   ├── compose.rs          # Docker compose.yaml parser
+│   └── package_swift.rs    # Swift Package.swift parser
 │
 └── version/                 # Version Management Layer
     ├── mod.rs              # Module documentation & architecture diagram
@@ -132,7 +135,8 @@ src/
         ├── pypi.rs         # PyPI PEP 508 matching
         ├── jsr.rs          # JSR semver range matching
         ├── pnpm_catalog.rs # pnpm catalog (reuses npm matching)
-        └── docker.rs       # Docker suffix-aware tag matching
+        ├── docker.rs       # Docker suffix-aware tag matching
+        └── swift_pm.rs     # SPM matcher (reuses Cargo caret semantics)
 ```
 
 ---
@@ -339,6 +343,7 @@ pub trait VersionMatcher: Send + Sync {
 | JsrMatcher         | `^1.2.3`, `~1.2.3`              | semver range evaluation                                |
 | PnpmCatalogMatcher | `^1.2.3`, `~1.2.3`              | semver range (same as npm)                             |
 | DockerMatcher      | `1.25`, `1.25-alpine`, `v1.0.0` | Suffix-aware tag comparison, `resolve_latest` override |
+| SwiftPmMatcher     | `1.2.3`, `>=1.0.0, <2.0.0` (bare or compound) | Caret-like for bare versions; ranges from SPM `..<`/`...` (parser produces compound). Strips `v` from GitHub tags. |
 
 ### Registry (src/version/registry.rs)
 
@@ -358,7 +363,7 @@ pub trait Registry: Send + Sync {
 | NpmRegistry     | `registry.npmjs.org/{pkg}`                             | dist-tags support, sorted by publish date |
 | CratesRegistry  | `crates.io/api/v1/crates/{pkg}`                        | Excludes yanked versions                  |
 | GoProxyRegistry | `proxy.golang.org/{mod}/@v/list`                       | Module path encoding                      |
-| GitHubRegistry  | `api.github.com/repos/{owner/repo}/releases`           | Rate limit handling                       |
+| GitHubRegistry  | `api.github.com/repos/{owner/repo}/releases`           | Rate limit handling; reused by SwiftPm    |
 | PypiRegistry    | `pypi.org/pypi/{pkg}/json`                             | Excludes yanked versions                  |
 | JsrRegistry     | `jsr.io/api/scopes/{scope}/packages/{pkg}`             | JSR scoped packages                       |
 | DockerRegistry  | Docker Hub: `registry-1.docker.io`, ghcr.io: `ghcr.io` | Token auth, tag filtering/sorting         |
@@ -396,6 +401,7 @@ hit the new URLs. The cache is not invalidated.
       "pypi": { "enabled": true, "url": null },
       "pnpmCatalog": { "enabled": true, "url": null },
       "jsr": { "enabled": true, "url": null },
+      "swiftPm": { "enabled": true, "url": null },
       "docker": {
         "enabled": true,
         "dockerHubRegistryUrl": null,
@@ -413,6 +419,13 @@ When a `url` is `null` (or absent), the registry uses its hardcoded default.
 URL-embedded credentials (`https://user:token@host/path`) are redacted from
 log output via a custom `Debug` impl on `RegistryConfig` and
 `DockerRegistryConfig`.
+
+For Swift Package Manager, the configured `swiftPm.url` does double duty: it
+overrides the GitHub API base URL the registry calls _and_ adds the URL's
+bare host to the parser's allow-list of accepted dependency hosts. This makes
+GitHub Enterprise mirrors work end-to-end: dependencies declared with
+`https://github.example.com/owner/repo.git` URLs are extracted and checked
+against the configured Enterprise API.
 
 ### Constants
 
@@ -471,7 +484,8 @@ tests/
 ├── e2e_github.rs      # GitHub Actions E2E tests
 ├── e2e_jsr.rs         # JSR E2E tests
 ├── e2e_pnpm.rs        # pnpm catalog E2E tests
-└── e2e_docker.rs      # Docker Hub / ghcr.io E2E tests
+├── e2e_docker.rs      # Docker Hub / ghcr.io E2E tests
+└── e2e_swift_pm.rs    # Swift Package Manager E2E tests
 ```
 
 ### Test Patterns

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,8 @@ pub struct RegistriesConfig {
     pub jsr: RegistryConfig,
     pub pypi: RegistryConfig,
     pub docker: DockerRegistryConfig,
+    #[serde(rename = "swiftPm")]
+    pub swift_pm: RegistryConfig,
 }
 
 /// Individual registry configuration with optional URL override
@@ -270,6 +272,7 @@ mod tests {
                         url: None
                     },
                     docker: DockerRegistryConfig::default(),
+                    swift_pm: RegistryConfig::default(),
                 },
                 ignore_prerelease: true,
             }
@@ -298,6 +301,27 @@ mod tests {
             RegistryConfig {
                 enabled: false,
                 url: Some("https://npm.internal/".to_string())
+            }
+        );
+    }
+
+    #[test]
+    fn swift_pm_config_parses_camel_case_key() {
+        let result = serde_json::from_value::<LspConfig>(json!({
+            "registries": {
+                "swiftPm": {
+                    "enabled": false,
+                    "url": "https://internal.github.example.com"
+                }
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            result.registries.swift_pm,
+            RegistryConfig {
+                enabled: false,
+                url: Some("https://internal.github.example.com".to_string()),
             }
         );
     }

--- a/src/lsp/backend.rs
+++ b/src/lsp/backend.rs
@@ -121,6 +121,7 @@ impl<S: VersionStorer> Backend<S> {
             RegistryType::Jsr => config.registries.jsr.enabled,
             RegistryType::PyPI => config.registries.pypi.enabled,
             RegistryType::Docker => config.registries.docker.enabled,
+            RegistryType::SwiftPm => config.registries.swift_pm.enabled,
         }
     }
 

--- a/src/lsp/resolver.rs
+++ b/src/lsp/resolver.rs
@@ -13,6 +13,7 @@ use crate::parser::deno_json::DenoJsonParser;
 use crate::parser::github_actions::GitHubActionsParser;
 use crate::parser::go_mod::GoModParser;
 use crate::parser::package_json::PackageJsonParser;
+use crate::parser::package_swift::PackageSwiftParser;
 use crate::parser::pnpm_workspace::PnpmWorkspaceParser;
 use crate::parser::pyproject_toml::PyprojectTomlParser;
 use crate::parser::traits::Parser;
@@ -21,6 +22,7 @@ use crate::version::matcher::VersionMatcher;
 use crate::version::matchers::{
     CratesVersionMatcher, DockerVersionMatcher, GitHubActionsMatcher, GoVersionMatcher,
     JsrVersionMatcher, NpmVersionMatcher, PnpmCatalogMatcher, PypiVersionMatcher,
+    SwiftPmVersionMatcher,
 };
 use crate::version::registries::crates_io::CratesIoRegistry;
 use crate::version::registries::docker::DockerRegistry;
@@ -193,6 +195,15 @@ pub fn create_resolvers(config: &LspConfig) -> HashMap<RegistryType, PackageReso
         ),
     );
 
+    resolvers.insert(
+        RegistryType::SwiftPm,
+        PackageResolver::new(
+            Arc::new(swift_pm_parser_from(&registries.swift_pm)),
+            Arc::new(SwiftPmVersionMatcher),
+            Arc::new(swift_pm_registry_from(&registries.swift_pm)),
+        ),
+    );
+
     resolvers
 }
 
@@ -243,6 +254,59 @@ fn github_registry_from(cfg: &RegistryConfig) -> GitHubRegistry {
     }
 }
 
+/// Build a `GitHubRegistry` configured to report `RegistryType::SwiftPm`.
+/// Swift Package Manager dependencies live on GitHub, so we reuse the GitHub
+/// Releases API backend but tag the resulting registry with the SwiftPm type
+/// so cache lookups and resolver routing stay separated from GitHub Actions.
+fn swift_pm_registry_from(cfg: &RegistryConfig) -> GitHubRegistry {
+    let registry = if let Some(url) = cfg.url.as_deref() {
+        GitHubRegistry::new(url)
+    } else {
+        GitHubRegistry::default()
+    };
+    registry.with_registry_type(RegistryType::SwiftPm)
+}
+
+/// Build a `PackageSwiftParser` whose allow-list includes `github.com` plus
+/// the host extracted from `cfg.url` (if any). This is what makes private
+/// GitHub Enterprise mirrors work: setting `registries.swiftPm.url =
+/// "https://github.example.com/api/v3"` causes the parser to also accept
+/// dependency URLs hosted at `github.example.com`.
+fn swift_pm_parser_from(cfg: &RegistryConfig) -> PackageSwiftParser {
+    let extra_host = cfg.url.as_deref().and_then(host_from_url);
+    match extra_host {
+        Some(host) => PackageSwiftParser::with_allowed_hosts([host]),
+        None => PackageSwiftParser::new(),
+    }
+}
+
+/// Extract the host portion of an HTTP(S) URL (no port handling required —
+/// the hosts we compare against are bare hostnames like `github.example.com`).
+fn host_from_url(url: &str) -> Option<String> {
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let host_with_port = after_scheme
+        .split(['/', '?', '#'])
+        .next()
+        .filter(|s| !s.is_empty())?;
+    // Strip credentials (`user:pass@host`) and port (`host:443`) — we only
+    // care about the bare host for parser host matching.
+    let after_userinfo = host_with_port
+        .rsplit_once('@')
+        .map(|(_, host)| host)
+        .unwrap_or(host_with_port);
+    let host = after_userinfo
+        .split_once(':')
+        .map(|(host, _)| host)
+        .unwrap_or(after_userinfo);
+    if host.is_empty() {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -261,6 +325,7 @@ mod tests {
             RegistryType::Jsr,
             RegistryType::PyPI,
             RegistryType::Docker,
+            RegistryType::SwiftPm,
         ] {
             assert!(
                 resolvers.contains_key(&registry_type),
@@ -268,6 +333,16 @@ mod tests {
                 registry_type
             );
         }
+    }
+
+    #[test]
+    fn swift_pm_resolver_reports_swift_pm_registry_type() {
+        let resolvers = create_resolvers(&LspConfig::default());
+        let registry = resolvers
+            .get(&RegistryType::SwiftPm)
+            .expect("SwiftPm resolver missing")
+            .registry();
+        assert_eq!(registry.registry_type(), RegistryType::SwiftPm);
     }
 
     #[tokio::test]
@@ -425,5 +500,74 @@ mod tests {
 
         let resolvers = create_resolvers(&config);
         assert!(resolvers.contains_key(&RegistryType::Docker));
+    }
+
+    #[tokio::test]
+    async fn swift_pm_resolver_routes_fetches_to_overridden_url() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("GET", "/repos/team/internal-lib/releases")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"[{"tag_name": "v1.2.0", "published_at": "2024-01-15T00:00:00Z"}]"#)
+            .create_async()
+            .await;
+
+        let mut config = LspConfig::default();
+        config.registries.swift_pm.url = Some(server.url());
+
+        let resolvers = create_resolvers(&config);
+        let registry = resolvers
+            .get(&RegistryType::SwiftPm)
+            .expect("SwiftPm resolver missing")
+            .registry();
+
+        let result = registry
+            .fetch_all_versions("team/internal-lib")
+            .await
+            .unwrap();
+
+        mock.assert_async().await;
+        assert_eq!(result.versions, vec!["v1.2.0"]);
+    }
+
+    #[test]
+    fn swift_pm_parser_accepts_host_extracted_from_configured_url() {
+        let mut config = LspConfig::default();
+        config.registries.swift_pm.url = Some("https://github.example.com/api/v3".to_string());
+
+        let resolvers = create_resolvers(&config);
+        let parser = resolvers
+            .get(&RegistryType::SwiftPm)
+            .expect("SwiftPm resolver missing")
+            .parser();
+
+        // Round-trip a private-host dependency through the parser to confirm
+        // the resolver builder wired the override host through.
+        let manifest = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.example.com/team/internal-lib.git", from: "1.0.0"),
+    ]
+)
+"#;
+        let packages = parser.parse(manifest).unwrap();
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "team/internal-lib");
+    }
+
+    #[rstest::rstest]
+    #[case("https://github.example.com", Some("github.example.com"))]
+    #[case("https://github.example.com/api/v3", Some("github.example.com"))]
+    #[case(
+        "https://user:token@github.example.com/api/v3",
+        Some("github.example.com")
+    )]
+    #[case("https://github.example.com:8443/api/v3", Some("github.example.com"))]
+    #[case("http://github.example.com", Some("github.example.com"))]
+    #[case("not-a-url", None)]
+    #[case("ftp://example.com", None)]
+    fn host_from_url_extracts_bare_host(#[case] url: &str, #[case] expected: Option<&str>) {
+        assert_eq!(host_from_url(url).as_deref(), expected);
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -8,6 +8,7 @@
 //! - pnpm_workspace.rs: pnpm-workspace.yaml catalog parser
 //! - deno_json.rs: deno.json parser
 //! - pyproject_toml.rs: pyproject.toml parser
+//! - package_swift.rs: Package.swift (Swift Package Manager) parser
 
 pub mod cargo_toml;
 pub mod compose;
@@ -15,6 +16,7 @@ pub mod deno_json;
 pub mod github_actions;
 pub mod go_mod;
 pub mod package_json;
+pub mod package_swift;
 pub mod pnpm_workspace;
 pub mod pyproject_toml;
 pub mod traits;
@@ -26,6 +28,7 @@ pub use deno_json::DenoJsonParser;
 pub use github_actions::GitHubActionsParser;
 pub use go_mod::GoModParser;
 pub use package_json::PackageJsonParser;
+pub use package_swift::PackageSwiftParser;
 pub use pnpm_workspace::PnpmWorkspaceParser;
 pub use pyproject_toml::PyprojectTomlParser;
 pub use traits::{ParseError, Parser};

--- a/src/parser/package_swift.rs
+++ b/src/parser/package_swift.rs
@@ -1,0 +1,700 @@
+//! Package.swift parser
+//!
+//! Parses Swift Package Manager manifests, extracting dependencies declared via
+//! `.package(url: ..., from: ...)` and related forms.
+//!
+//! Supported version constraint forms:
+//! - `.package(url: "https://github.com/x/y.git", from: "1.2.3")`
+//! - `.package(url: "https://github.com/x/y.git", exact: "1.2.3")`
+//! - `.package(url: "https://github.com/x/y.git", .upToNextMajor(from: "1.2.3"))`
+//! - `.package(url: "https://github.com/x/y.git", .upToNextMinor(from: "1.2.3"))`
+//! - `.package(url: "https://github.com/x/y.git", "1.0.0" ..< "2.0.0")`
+//! - `.package(url: "https://github.com/x/y.git", "1.0.0" ... "2.0.0")`
+//!
+//! Branch and revision pins (`branch:`, `revision:`) and non-version-pinned
+//! dependencies are skipped, since they have no version to compare. By default
+//! only `github.com` URLs are emitted; additional hosts can be supplied via
+//! [`PackageSwiftParser::with_allowed_hosts`] (typically derived from the
+//! configured `swiftPm.url` so private GitHub Enterprise mirrors work).
+
+use tracing::{debug, warn};
+
+use crate::parser::traits::{ParseError, Parser};
+use crate::parser::types::{PackageInfo, RegistryType};
+
+/// Default Git host accepted when no explicit allow-list is configured.
+pub const DEFAULT_ALLOWED_HOST: &str = "github.com";
+
+pub struct PackageSwiftParser {
+    /// Lowercased Git hosts whose `owner/repo` URLs should be extracted.
+    /// Always contains at least `github.com`.
+    allowed_hosts: Vec<String>,
+}
+
+impl PackageSwiftParser {
+    /// Create a parser that only accepts the default GitHub host.
+    pub fn new() -> Self {
+        Self {
+            allowed_hosts: vec![DEFAULT_ALLOWED_HOST.to_string()],
+        }
+    }
+
+    /// Create a parser that accepts the default GitHub host plus any additional
+    /// hosts supplied (typically the host of a private GitHub Enterprise
+    /// mirror configured via `registries.swiftPm.url`).
+    ///
+    /// Hosts are compared case-insensitively. Empty strings are ignored.
+    /// `github.com` is always accepted regardless of input.
+    pub fn with_allowed_hosts<I, S>(extra_hosts: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let mut allowed = vec![DEFAULT_ALLOWED_HOST.to_string()];
+        for host in extra_hosts {
+            let host = host.as_ref().trim().to_ascii_lowercase();
+            if host.is_empty() || allowed.iter().any(|h| h == &host) {
+                continue;
+            }
+            allowed.push(host);
+        }
+        Self {
+            allowed_hosts: allowed,
+        }
+    }
+}
+
+impl Default for PackageSwiftParser {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Parser for PackageSwiftParser {
+    fn parse(&self, content: &str) -> Result<Vec<PackageInfo>, ParseError> {
+        let mut parser = tree_sitter::Parser::new();
+        let language = tree_sitter_swift::LANGUAGE;
+        parser.set_language(&language.into()).map_err(|e| {
+            warn!("Failed to set Swift language for tree-sitter: {}", e);
+            ParseError::TreeSitter(e.to_string())
+        })?;
+
+        let tree = parser.parse(content, None).ok_or_else(|| {
+            warn!("Failed to parse Swift content");
+            ParseError::ParseFailed("Failed to parse Swift".to_string())
+        })?;
+
+        let mut results = Vec::new();
+        self.walk_for_package_calls(tree.root_node(), content, &mut results);
+        Ok(results)
+    }
+}
+
+/// Recursively walk the tree looking for `.package(...)` call expressions.
+impl PackageSwiftParser {
+    fn walk_for_package_calls(
+        &self,
+        node: tree_sitter::Node,
+        content: &str,
+        results: &mut Vec<PackageInfo>,
+    ) {
+        if node.kind() == "call_expression" && is_package_call(node, content) {
+            if let Some(info) = self.extract_package_info(node, content) {
+                results.push(info);
+            }
+            // Don't recurse into the matched .package(...) call: nested `.upToNextMajor(...)`
+            // is not itself a top-level dependency declaration.
+            return;
+        }
+
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_for_package_calls(child, content, results);
+        }
+    }
+
+    /// Extract `PackageInfo` from a `.package(...)` call expression. Returns `None`
+    /// if the call cannot be turned into a version-pinned dependency we can check
+    /// (e.g. branch/revision pins, non-allowed-host URLs, or malformed input).
+    fn extract_package_info(&self, node: tree_sitter::Node, content: &str) -> Option<PackageInfo> {
+        let value_arguments = find_value_arguments(node)?;
+
+        let mut url: Option<String> = None;
+        let mut version_field: Option<VersionField> = None;
+
+        let mut cursor = value_arguments.walk();
+        for arg in value_arguments.children(&mut cursor) {
+            if arg.kind() != "value_argument" {
+                continue;
+            }
+
+            let label = label_text(arg, content);
+
+            match label.as_deref() {
+                Some("url") => {
+                    url = string_literal_value(arg, content);
+                }
+                Some("from") | Some("exact") => {
+                    version_field = extract_string_field(arg, content);
+                }
+                Some("branch") | Some("revision") | Some("name") | Some("path") => {
+                    // Skip — no version to check.
+                }
+                _ => {
+                    // Positional argument: may be a `.upToNextMajor(from: "...")`,
+                    // `.upToNextMinor(from: "...")`, or a range like `"1.0.0" ..< "2.0.0"`.
+                    if let Some(field) = extract_constructor_version(arg, content) {
+                        version_field = Some(field);
+                    } else if let Some(field) = extract_range_version(arg, content) {
+                        version_field = Some(field);
+                    }
+                }
+            }
+        }
+
+        let url = url?;
+        let version_field = version_field?;
+        let name = self.owner_repo_for_url(&url)?;
+
+        Some(PackageInfo {
+            name,
+            version: version_field.version,
+            commit_hash: None,
+            registry_type: RegistryType::SwiftPm,
+            start_offset: version_field.start_offset,
+            end_offset: version_field.end_offset,
+            line: version_field.line,
+            column: version_field.column,
+            extra_info: None,
+        })
+    }
+
+    /// Convert a Git URL into the `owner/repo` slug used by the GitHub
+    /// Releases API. Returns `None` if the URL's host is not in the
+    /// allow-list or the URL is malformed.
+    ///
+    /// Accepts both HTTPS (`https://host/owner/repo[.git][/]`) and SSH
+    /// (`git@host:owner/repo[.git]`) forms.
+    fn owner_repo_for_url(&self, url: &str) -> Option<String> {
+        let (host, rest) = split_host_and_path(url)?;
+        if !self.allowed_hosts.iter().any(|h| h == &host) {
+            debug!(
+                "Skipping SPM dependency: host '{}' not in allowed_hosts {:?}",
+                host, self.allowed_hosts
+            );
+            return None;
+        }
+        parse_owner_repo(rest)
+    }
+}
+
+/// Check whether a `call_expression` is a `.package(...)` member call.
+fn is_package_call(node: tree_sitter::Node, content: &str) -> bool {
+    let Some(prefix) = first_child_of_kind(node, "prefix_expression") else {
+        return false;
+    };
+    // prefix_expression children: ".", simple_identifier
+    let Some(ident) = first_child_of_kind(prefix, "simple_identifier") else {
+        return false;
+    };
+    content[ident.byte_range()].trim() == "package"
+}
+
+/// A located version literal (start/end offsets bracket the version text in the
+/// source — for single-version constraints they exclude the surrounding quotes;
+/// for range expressions they span both bounds plus the operator so the
+/// diagnostic underline covers the whole range).
+struct VersionField {
+    version: String,
+    start_offset: usize,
+    end_offset: usize,
+    line: usize,
+    column: usize,
+}
+
+/// Locate the `value_arguments` node inside a `.package(...)` call_expression.
+fn find_value_arguments(call: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut cursor = call.walk();
+    for child in call.children(&mut cursor) {
+        if child.kind() == "call_suffix" {
+            let mut suffix_cursor = child.walk();
+            for grandchild in child.children(&mut suffix_cursor) {
+                if grandchild.kind() == "value_arguments" {
+                    return Some(grandchild);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Read the label of a `value_argument` node (e.g. "url", "from", "exact").
+fn label_text(arg: tree_sitter::Node, content: &str) -> Option<String> {
+    let mut cursor = arg.walk();
+    for child in arg.children(&mut cursor) {
+        if child.kind() == "value_argument_label" {
+            let mut label_cursor = child.walk();
+            for inner in child.children(&mut label_cursor) {
+                if inner.kind() == "simple_identifier" {
+                    return Some(content[inner.byte_range()].to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract the inner text of a `line_string_literal` child of a `value_argument`.
+fn string_literal_value(arg: tree_sitter::Node, content: &str) -> Option<String> {
+    line_str_text_node(arg).map(|node| content[node.byte_range()].to_string())
+}
+
+/// Extract a `VersionField` from a `value_argument` whose value is a `line_string_literal`.
+/// Used for `from: "..."` and `exact: "..."`.
+fn extract_string_field(arg: tree_sitter::Node, content: &str) -> Option<VersionField> {
+    let str_text = line_str_text_node(arg)?;
+    let start_point = str_text.start_position();
+    Some(VersionField {
+        version: content[str_text.byte_range()].to_string(),
+        start_offset: str_text.start_byte(),
+        end_offset: str_text.end_byte(),
+        line: start_point.row,
+        column: start_point.column,
+    })
+}
+
+/// Extract a `VersionField` from a positional argument that is itself a
+/// `call_expression` such as `.upToNextMajor(from: "1.2.3")` or
+/// `.upToNextMinor(from: "1.2.3")`.
+fn extract_constructor_version(arg: tree_sitter::Node, content: &str) -> Option<VersionField> {
+    let call = first_child_of_kind(arg, "call_expression")?;
+
+    // Verify the prefix identifier is one we recognize.
+    let prefix = first_child_of_kind(call, "prefix_expression")?;
+    let ident_node = first_child_of_kind(prefix, "simple_identifier")?;
+    let ident = &content[ident_node.byte_range()];
+    if ident != "upToNextMajor" && ident != "upToNextMinor" {
+        return None;
+    }
+
+    // Find the inner `from: "..."` argument.
+    let suffix = first_child_of_kind(call, "call_suffix")?;
+    let inner_args = first_child_of_kind(suffix, "value_arguments")?;
+    let mut cursor = inner_args.walk();
+    for inner in inner_args.children(&mut cursor) {
+        if inner.kind() != "value_argument" {
+            continue;
+        }
+        if label_text(inner, content).as_deref() == Some("from") {
+            return extract_string_field(inner, content);
+        }
+    }
+    None
+}
+
+/// Extract a `VersionField` from a positional argument that is a Swift range
+/// expression: `"A" ..< "B"` (half-open) or `"A" ... "B"` (closed).
+///
+/// Half-open ranges become `>=A, <B` (Cargo-compound, matching SPM semantics).
+/// Closed ranges become `>=A, <=B`. The matcher delegates to the Cargo matcher
+/// which already understands comma-separated AND requirements.
+///
+/// Offsets span from the start of the lower bound (excluding its leading `"`)
+/// through the end of the upper bound (excluding its trailing `"`), so the
+/// diagnostic underline covers the entire range expression.
+fn extract_range_version(arg: tree_sitter::Node, content: &str) -> Option<VersionField> {
+    let range = first_child_of_kind(arg, "range_expression")?;
+
+    // Collect the two string-literal bounds and the operator kind.
+    let mut bounds: Vec<tree_sitter::Node> = Vec::with_capacity(2);
+    let mut operator: Option<&str> = None;
+    let mut cursor = range.walk();
+    for child in range.children(&mut cursor) {
+        match child.kind() {
+            "line_string_literal" => bounds.push(child),
+            "..<" => operator = Some("..<"),
+            "..." => operator = Some("..."),
+            _ => {}
+        }
+    }
+
+    if bounds.len() != 2 {
+        return None;
+    }
+    let op = operator?;
+
+    let lower_text = first_child_of_kind(bounds[0], "line_str_text")?;
+    let upper_text = first_child_of_kind(bounds[1], "line_str_text")?;
+
+    let lower = &content[lower_text.byte_range()];
+    let upper = &content[upper_text.byte_range()];
+
+    let upper_op = match op {
+        "..<" => "<",
+        "..." => "<=",
+        _ => return None,
+    };
+    let version = format!(">={}, {}{}", lower, upper_op, upper);
+
+    let start_point = lower_text.start_position();
+    Some(VersionField {
+        version,
+        // Span the full range expression (bound to bound, operator included)
+        // so diagnostics underline the user-visible source verbatim.
+        start_offset: lower_text.start_byte(),
+        end_offset: upper_text.end_byte(),
+        line: start_point.row,
+        column: start_point.column,
+    })
+}
+
+/// Find the inner `line_str_text` node of a value_argument's `line_string_literal`.
+fn line_str_text_node(arg: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let lit = first_child_of_kind(arg, "line_string_literal")?;
+    first_child_of_kind(lit, "line_str_text")
+}
+
+fn first_child_of_kind<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    let mut cursor = node.walk();
+    node.children(&mut cursor).find(|c| c.kind() == kind)
+}
+
+/// Split a Git URL into `(host, path_after_host)`. Returns `None` for
+/// unsupported schemes or malformed input. The returned host is lowercased
+/// for case-insensitive comparison against the parser's allow-list.
+///
+/// Accepts:
+/// - `https://host/owner/repo[.git][/]`
+/// - `http://host/owner/repo[.git][/]`
+/// - `git@host:owner/repo[.git]` (SSH)
+fn split_host_and_path(url: &str) -> Option<(String, &str)> {
+    let url = url.trim();
+
+    // SSH form: git@host:owner/repo.git
+    if let Some(rest) = url.strip_prefix("git@") {
+        let (host, path) = rest.split_once(':')?;
+        if host.is_empty() {
+            return None;
+        }
+        return Some((host.to_ascii_lowercase(), path));
+    }
+
+    // HTTPS / HTTP form
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let (host, path) = after_scheme.split_once('/')?;
+    if host.is_empty() {
+        return None;
+    }
+    Some((host.to_ascii_lowercase(), path))
+}
+
+fn parse_owner_repo(rest: &str) -> Option<String> {
+    let trimmed = rest.trim_end_matches('/');
+    let trimmed = trimmed.strip_suffix(".git").unwrap_or(trimmed);
+    let mut parts = trimmed.split('/');
+    let owner = parts.next()?;
+    let repo = parts.next()?;
+    if owner.is_empty() || repo.is_empty() {
+        return None;
+    }
+    // Reject anything past owner/repo (e.g. trailing tree paths) — those are
+    // not valid SPM package URLs.
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(format!("{}/{}", owner, repo))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[test]
+    fn parse_extracts_from_dependency() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        let pkg = &result[0];
+        assert_eq!(pkg.name, "vapor/vapor");
+        assert_eq!(pkg.version, "4.92.0");
+        assert_eq!(pkg.registry_type, RegistryType::SwiftPm);
+        assert!(pkg.commit_hash.is_none());
+        // Offsets should land on the version literal (excluding quotes).
+        assert_eq!(&content[pkg.start_offset..pkg.end_offset], "4.92.0");
+    }
+
+    #[test]
+    fn parse_extracts_exact_dependency() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", exact: "2.50.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "apple/swift-nio");
+        assert_eq!(result[0].version, "2.50.0");
+    }
+
+    #[test]
+    fn parse_extracts_up_to_next_major() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.0")),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "apple/swift-log");
+        assert_eq!(result[0].version, "1.5.0");
+    }
+
+    #[test]
+    fn parse_extracts_up_to_next_minor() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-metrics.git", .upToNextMinor(from: "2.4.0")),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "apple/swift-metrics");
+        assert_eq!(result[0].version, "2.4.0");
+    }
+
+    #[test]
+    fn parse_skips_branch_pin() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/some/repo.git", branch: "main"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_skips_revision_pin() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/some/repo.git", revision: "abc123"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_extracts_half_open_range_expression() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "apple/swift-crypto");
+        assert_eq!(result[0].version, ">=1.0.0, <5.0.0");
+        // Underline should span the full range expression in the source.
+        assert_eq!(
+            &content[result[0].start_offset..result[0].end_offset],
+            "1.0.0\" ..< \"5.0.0"
+        );
+    }
+
+    #[test]
+    fn parse_extracts_closed_range_expression() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ... "5.0.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "apple/swift-crypto");
+        assert_eq!(result[0].version, ">=1.0.0, <=5.0.0");
+    }
+
+    #[test]
+    fn parse_handles_range_expression_without_whitespace() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0"..<"5.0.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].version, ">=1.0.0, <5.0.0");
+    }
+
+    #[test]
+    fn parse_skips_non_allowed_host_by_default() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://gitlab.com/some/repo.git", from: "1.0.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_accepts_private_host_when_in_allowed_list() {
+        let parser = PackageSwiftParser::with_allowed_hosts(["github.example.com"]);
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.example.com/team/internal-lib.git", from: "1.0.0"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].name, "team/internal-lib");
+        assert_eq!(result[1].name, "vapor/vapor");
+    }
+
+    #[test]
+    fn parse_rejects_unlisted_host_even_with_other_allowed_hosts() {
+        let parser = PackageSwiftParser::with_allowed_hosts(["github.example.com"]);
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://gitlab.com/x/y.git", from: "1.0.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn with_allowed_hosts_is_case_insensitive_and_dedupes() {
+        let parser =
+            PackageSwiftParser::with_allowed_hosts(["GITHUB.COM", "GitHub.Example.Com", "  "]);
+        // github.com plus the (lowercased) private host; duplicates and empty
+        // entries are skipped.
+        assert_eq!(
+            parser.allowed_hosts,
+            vec!["github.com".to_string(), "github.example.com".to_string()]
+        );
+    }
+
+    #[rstest]
+    #[case("https://github.com/vapor/vapor.git", Some("vapor/vapor"))]
+    #[case("https://github.com/vapor/vapor", Some("vapor/vapor"))]
+    #[case("https://github.com/apple/swift-nio.git/", Some("apple/swift-nio"))]
+    #[case("git@github.com:vapor/vapor.git", Some("vapor/vapor"))]
+    #[case("https://gitlab.com/x/y.git", None)]
+    #[case("https://github.com/owner", None)]
+    #[case("https://github.com/owner/repo/extra", None)]
+    #[case("not-a-url", None)]
+    fn owner_repo_for_url_with_default_hosts(#[case] url: &str, #[case] expected: Option<&str>) {
+        let parser = PackageSwiftParser::new();
+        assert_eq!(parser.owner_repo_for_url(url).as_deref(), expected);
+    }
+
+    #[rstest]
+    #[case("https://github.example.com/team/lib.git", Some("team/lib"))]
+    #[case("git@github.example.com:team/lib.git", Some("team/lib"))]
+    #[case("https://github.com/vapor/vapor.git", Some("vapor/vapor"))]
+    #[case("https://gitlab.com/x/y.git", None)]
+    fn owner_repo_for_url_with_private_host(#[case] url: &str, #[case] expected: Option<&str>) {
+        let parser = PackageSwiftParser::with_allowed_hosts(["github.example.com"]);
+        assert_eq!(parser.owner_repo_for_url(url).as_deref(), expected);
+    }
+
+    #[test]
+    fn parse_extracts_multiple_dependencies() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.92.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", exact: "2.50.0"),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.0")),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 3);
+        assert_eq!(result[0].name, "vapor/vapor");
+        assert_eq!(result[0].version, "4.92.0");
+        assert_eq!(result[1].name, "apple/swift-nio");
+        assert_eq!(result[1].version, "2.50.0");
+        assert_eq!(result[2].name, "apple/swift-log");
+        assert_eq!(result[2].version, "1.5.0");
+    }
+
+    #[test]
+    fn parse_returns_empty_for_no_dependencies() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(name: "MyApp")
+"#;
+        let result = parser.parse(content).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn parse_handles_dotgit_suffix_and_trailing_slash() {
+        let parser = PackageSwiftParser::new();
+        let content = r#"import PackageDescription
+let package = Package(
+    dependencies: [
+        .package(url: "https://github.com/owner/repo/", from: "1.0.0"),
+    ]
+)
+"#;
+        let result = parser.parse(content).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].name, "owner/repo");
+    }
+}

--- a/src/parser/types.rs
+++ b/src/parser/types.rs
@@ -19,6 +19,8 @@ pub enum RegistryType {
     PyPI,
     /// Docker (compose.yaml)
     Docker,
+    /// Swift Package Manager (Package.swift)
+    SwiftPm,
 }
 
 impl RegistryType {
@@ -33,6 +35,7 @@ impl RegistryType {
             RegistryType::Jsr => "jsr",
             RegistryType::PyPI => "pypi",
             RegistryType::Docker => "docker",
+            RegistryType::SwiftPm => "swift_pm",
         }
     }
 }
@@ -50,6 +53,7 @@ impl std::str::FromStr for RegistryType {
             "jsr" => Ok(RegistryType::Jsr),
             "pypi" => Ok(RegistryType::PyPI),
             "docker" => Ok(RegistryType::Docker),
+            "swift_pm" => Ok(RegistryType::SwiftPm),
             _ => Err(()),
         }
     }
@@ -73,6 +77,8 @@ pub fn detect_parser_type(uri: &str) -> Option<RegistryType> {
         Some(RegistryType::PyPI)
     } else if is_compose_file(uri) {
         Some(RegistryType::Docker)
+    } else if uri.ends_with("/Package.swift") {
+        Some(RegistryType::SwiftPm)
     } else {
         None
     }
@@ -222,6 +228,9 @@ mod tests {
     #[case("/path/to/docker-compose.yaml", Some(RegistryType::Docker))]
     #[case("/path/to/docker-compose.yml", Some(RegistryType::Docker))]
     #[case("file:///home/user/compose.yaml", Some(RegistryType::Docker))]
+    #[case("/path/to/Package.swift", Some(RegistryType::SwiftPm))]
+    #[case("/project/Package.swift", Some(RegistryType::SwiftPm))]
+    #[case("file:///home/user/Package.swift", Some(RegistryType::SwiftPm))]
     #[case("workflow.yml", None)]
     #[case("random.txt", None)]
     fn detect_parser_type_returns_expected(

--- a/src/version/matchers/mod.rs
+++ b/src/version/matchers/mod.rs
@@ -8,6 +8,7 @@ pub mod jsr;
 pub mod npm;
 pub mod pnpm;
 pub mod pypi;
+pub mod swift_pm;
 
 pub use crates::CratesVersionMatcher;
 pub use docker::DockerVersionMatcher;
@@ -17,3 +18,4 @@ pub use jsr::JsrVersionMatcher;
 pub use npm::NpmVersionMatcher;
 pub use pnpm::PnpmCatalogMatcher;
 pub use pypi::PypiVersionMatcher;
+pub use swift_pm::SwiftPmVersionMatcher;

--- a/src/version/matchers/swift_pm.rs
+++ b/src/version/matchers/swift_pm.rs
@@ -1,0 +1,120 @@
+//! Swift Package Manager version matcher
+//!
+//! SPM dependencies use semver constraints. The semantic of a bare `from: "1.2.3"`
+//! is "compatible with 1.2.3" — identical to Cargo's bare `1.2.3` (caret-like).
+//! `exact:` declares an exact version, and `.upToNextMajor`/`.upToNextMinor`
+//! are caret/tilde respectively. Since the parser stores only the version
+//! literal (no operator prefix), we delegate to the Cargo matcher whose
+//! default-caret behavior matches SPM's `from:` semantics.
+
+use crate::parser::types::RegistryType;
+use crate::version::matcher::VersionMatcher;
+use crate::version::matchers::CratesVersionMatcher;
+use crate::version::semver::CompareResult;
+
+pub struct SwiftPmVersionMatcher;
+
+impl VersionMatcher for SwiftPmVersionMatcher {
+    fn registry_type(&self) -> RegistryType {
+        RegistryType::SwiftPm
+    }
+
+    fn version_exists(&self, version_spec: &str, available_versions: &[String]) -> bool {
+        // GitHub Releases tag names typically use a `v` prefix (e.g. `v4.92.0`).
+        // SPM constraint versions are bare (e.g. `4.92.0`). Strip the `v` prefix
+        // from available versions so the Cargo matcher's semver comparison works.
+        let normalized = strip_v_prefix(available_versions);
+        CratesVersionMatcher.version_exists(version_spec, &normalized)
+    }
+
+    fn compare_to_latest(&self, current_version: &str, latest_version: &str) -> CompareResult {
+        let latest_stripped = latest_version
+            .strip_prefix('v')
+            .unwrap_or(latest_version)
+            .to_string();
+        CratesVersionMatcher.compare_to_latest(current_version, &latest_stripped)
+    }
+
+    /// Strip the `v` prefix from the latest version so diagnostics show
+    /// `Update available: 4.90.0 -> 5.0.0` instead of `... -> v5.0.0`,
+    /// matching the form users write in Package.swift.
+    fn resolve_latest(
+        &self,
+        _current_version: &str,
+        latest_version: &str,
+        _all_versions: &[String],
+    ) -> String {
+        latest_version
+            .strip_prefix('v')
+            .unwrap_or(latest_version)
+            .to_string()
+    }
+}
+
+fn strip_v_prefix(versions: &[String]) -> Vec<String> {
+    versions
+        .iter()
+        .map(|v| v.strip_prefix('v').unwrap_or(v).to_string())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_type_returns_swift_pm() {
+        assert_eq!(SwiftPmVersionMatcher.registry_type(), RegistryType::SwiftPm);
+    }
+
+    #[test]
+    fn version_exists_matches_bare_against_v_prefixed_tags() {
+        let tags = vec![
+            "v1.0.0".to_string(),
+            "v1.2.3".to_string(),
+            "v2.0.0".to_string(),
+        ];
+        assert!(SwiftPmVersionMatcher.version_exists("1.2.3", &tags));
+        assert!(SwiftPmVersionMatcher.version_exists("1.0.0", &tags));
+        assert!(!SwiftPmVersionMatcher.version_exists("9.9.9", &tags));
+    }
+
+    #[test]
+    fn version_exists_matches_bare_against_bare_tags() {
+        let tags = vec!["1.0.0".to_string(), "1.2.3".to_string()];
+        assert!(SwiftPmVersionMatcher.version_exists("1.2.3", &tags));
+    }
+
+    #[test]
+    fn compare_to_latest_treats_bare_as_caret_like_cargo() {
+        // Bare `1.0.0` should be considered compatible with `1.5.0`
+        // (caret semantics, same as Cargo's default behavior).
+        assert_eq!(
+            SwiftPmVersionMatcher.compare_to_latest("1.0.0", "1.5.0"),
+            CompareResult::Latest
+        );
+    }
+
+    #[test]
+    fn compare_to_latest_flags_outdated_when_major_lags() {
+        assert_eq!(
+            SwiftPmVersionMatcher.compare_to_latest("1.0.0", "2.0.0"),
+            CompareResult::Outdated
+        );
+    }
+
+    #[test]
+    fn compare_to_latest_strips_v_prefix_from_latest() {
+        assert_eq!(
+            SwiftPmVersionMatcher.compare_to_latest("4.92.0", "v4.92.0"),
+            CompareResult::Latest
+        );
+    }
+
+    #[test]
+    fn resolve_latest_strips_v_prefix() {
+        let m = SwiftPmVersionMatcher;
+        assert_eq!(m.resolve_latest("1.0.0", "v2.5.0", &[]), "2.5.0");
+        assert_eq!(m.resolve_latest("1.0.0", "2.5.0", &[]), "2.5.0");
+    }
+}

--- a/src/version/registries/github.rs
+++ b/src/version/registries/github.rs
@@ -46,10 +46,14 @@ pub trait TagShaFetcher: Send + Sync {
 pub struct GitHubRegistry {
     client: reqwest::Client,
     base_url: String,
+    registry_type: RegistryType,
 }
 
 impl GitHubRegistry {
-    /// Creates a new GitHubRegistry with a custom base URL
+    /// Creates a new GitHubRegistry with a custom base URL. The reported
+    /// `registry_type()` defaults to [`RegistryType::GitHubActions`]; use
+    /// [`Self::with_registry_type`] to override it for other consumers
+    /// (e.g. Swift Package Manager).
     pub fn new(base_url: &str) -> Self {
         Self {
             client: reqwest::Client::builder()
@@ -57,7 +61,16 @@ impl GitHubRegistry {
                 .build()
                 .expect("Failed to create HTTP client"),
             base_url: base_url.to_string(),
+            registry_type: RegistryType::GitHubActions,
         }
+    }
+
+    /// Override the [`RegistryType`] reported by this registry instance.
+    /// The HTTP behavior is identical regardless of registry type — this
+    /// only affects the value returned by [`Registry::registry_type`].
+    pub fn with_registry_type(mut self, registry_type: RegistryType) -> Self {
+        self.registry_type = registry_type;
+        self
     }
 }
 
@@ -73,7 +86,7 @@ impl Default for GitHubRegistry {
 #[async_trait::async_trait]
 impl Registry for GitHubRegistry {
     fn registry_type(&self) -> RegistryType {
-        RegistryType::GitHubActions
+        self.registry_type
     }
 
     async fn fetch_all_versions(
@@ -201,6 +214,19 @@ impl TagShaFetcher for GitHubRegistry {
 mod tests {
     use super::*;
     use mockito::Server;
+
+    #[test]
+    fn registry_type_defaults_to_github_actions() {
+        let registry = GitHubRegistry::new("https://api.github.com");
+        assert_eq!(registry.registry_type(), RegistryType::GitHubActions);
+    }
+
+    #[test]
+    fn with_registry_type_overrides_reported_type() {
+        let registry =
+            GitHubRegistry::new("https://api.github.com").with_registry_type(RegistryType::SwiftPm);
+        assert_eq!(registry.registry_type(), RegistryType::SwiftPm);
+    }
 
     #[tokio::test]
     async fn fetch_all_versions_returns_releases_sorted_by_published_at() {

--- a/tests/e2e_swift_pm.rs
+++ b/tests/e2e_swift_pm.rs
@@ -1,0 +1,495 @@
+//! Swift Package Manager (Package.swift) E2E tests
+
+mod helper;
+
+use std::collections::HashMap;
+
+use tower::Service;
+use tower_lsp::LspService;
+use tower_lsp::lsp_types::*;
+
+use helper::{
+    MockRegistry, create_did_open_notification, create_initialize_request,
+    create_initialized_notification, create_swift_pm_resolver_with_hosts, create_test_cache,
+    create_test_resolver, spawn_notification_collector, wait_for_notification,
+};
+use version_lsp::lsp::backend::Backend;
+use version_lsp::lsp::resolver::PackageResolver;
+use version_lsp::parser::types::RegistryType;
+
+/// GitHub release tags conventionally have a `v` prefix; SwiftPmVersionMatcher
+/// strips it before comparing against the bare versions in Package.swift.
+fn make_resolvers(
+    package_name: &str,
+    versions: Vec<&str>,
+) -> HashMap<RegistryType, PackageResolver> {
+    let registry = MockRegistry::new(RegistryType::SwiftPm).with_versions(package_name, versions);
+    HashMap::from([(
+        RegistryType::SwiftPm,
+        create_test_resolver(RegistryType::SwiftPm, registry),
+    )])
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publishes_outdated_version_warning() {
+    // `from: "4.90.0"` is caret-like (>=4.90.0, <5.0.0). When the latest
+    // available version is in a new major (5.0.0), the dependency is outdated.
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("vapor/vapor", vec!["v4.90.0", "v4.95.0", "v5.0.0"])],
+    );
+
+    let resolvers = make_resolvers("vapor/vapor", vec!["v4.90.0", "v4.95.0", "v5.0.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "MyApp",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.90.0"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert_eq!(params.diagnostics.len(), 1);
+    assert_eq!(
+        params.diagnostics[0].severity,
+        Some(DiagnosticSeverity::WARNING)
+    );
+    assert_eq!(
+        params.diagnostics[0].message,
+        "Update available: 4.90.0 -> 5.0.0"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn no_diagnostics_for_latest_version() {
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("apple/swift-nio", vec!["v2.50.0", "v2.51.0"])],
+    );
+
+    let resolvers = make_resolvers("apple/swift-nio", vec!["v2.50.0", "v2.51.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    // `from: "2.50.0"` is caret-like, so latest 2.51.0 satisfies it.
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.50.0"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert!(params.diagnostics.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn publishes_error_for_nonexistent_version() {
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("vapor/vapor", vec!["v4.90.0", "v4.92.0"])],
+    );
+
+    let resolvers = make_resolvers("vapor/vapor", vec!["v4.90.0", "v4.92.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", exact: "9.9.9"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert_eq!(params.diagnostics.len(), 1);
+    assert_eq!(
+        params.diagnostics[0].severity,
+        Some(DiagnosticSeverity::ERROR)
+    );
+    assert_eq!(
+        params.diagnostics[0].message,
+        "Version 9.9.9 not found in registry"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn up_to_next_major_is_latest_when_satisfied() {
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("apple/swift-log", vec!["v1.5.0", "v1.6.0", "v1.7.0"])],
+    );
+
+    let resolvers = make_resolvers("apple/swift-log", vec!["v1.5.0", "v1.6.0", "v1.7.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.5.0")),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert!(params.diagnostics.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn skips_branch_pinned_dependency() {
+    let (_temp_dir, cache) = create_test_cache(RegistryType::SwiftPm, &[]);
+
+    let resolvers = make_resolvers("some/repo", vec!["v1.0.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/some/repo.git", branch: "main"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert!(params.diagnostics.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn half_open_range_is_latest_when_satisfied() {
+    // `"1.0.0" ..< "5.0.0"` becomes `>=1.0.0, <5.0.0`. When the registry's
+    // latest is `4.9.0`, the range satisfies it — no diagnostic.
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("apple/swift-crypto", vec!["v1.0.0", "v3.0.0", "v4.9.0"])],
+    );
+
+    let resolvers = make_resolvers("apple/swift-crypto", vec!["v1.0.0", "v3.0.0", "v4.9.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert!(params.diagnostics.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn half_open_range_warns_when_latest_exceeds_upper_bound() {
+    // `"1.0.0" ..< "5.0.0"` becomes `>=1.0.0, <5.0.0`. Latest is `5.1.0`,
+    // outside the range — warning expected.
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("apple/swift-crypto", vec!["v1.0.0", "v4.9.0", "v5.1.0"])],
+    );
+
+    let resolvers = make_resolvers("apple/swift-crypto", vec!["v1.0.0", "v4.9.0", "v5.1.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "5.0.0"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert_eq!(params.diagnostics.len(), 1);
+    assert_eq!(
+        params.diagnostics[0].severity,
+        Some(DiagnosticSeverity::WARNING)
+    );
+    assert_eq!(
+        params.diagnostics[0].message,
+        "Update available: >=1.0.0, <5.0.0 -> 5.1.0"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn closed_range_includes_upper_bound() {
+    // `"1.0.0" ... "5.0.0"` becomes `>=1.0.0, <=5.0.0`. Latest `5.0.0` is
+    // within the closed range — no diagnostic.
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("apple/swift-crypto", vec!["v1.0.0", "v4.0.0", "v5.0.0"])],
+    );
+
+    let resolvers = make_resolvers("apple/swift-crypto", vec!["v1.0.0", "v4.0.0", "v5.0.0"]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ... "5.0.0"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert!(params.diagnostics.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn private_github_enterprise_host_is_checked_when_configured() {
+    // Simulates `registries.swiftPm.url = "https://github.example.com/api/v3"`.
+    // The parser is built with `github.example.com` in its allow-list, so the
+    // dependency on that host is extracted and version-checked.
+    let (_temp_dir, cache) = create_test_cache(
+        RegistryType::SwiftPm,
+        &[("team/internal-lib", vec!["v1.0.0", "v1.5.0", "v2.0.0"])],
+    );
+
+    let registry = MockRegistry::new(RegistryType::SwiftPm)
+        .with_versions("team/internal-lib", vec!["v1.0.0", "v1.5.0", "v2.0.0"]);
+
+    let resolvers: HashMap<RegistryType, PackageResolver> = HashMap::from([(
+        RegistryType::SwiftPm,
+        create_swift_pm_resolver_with_hosts(registry, ["github.example.com"]),
+    )]);
+
+    let (mut service, socket) =
+        LspService::build(|client| Backend::build(client, cache.clone(), resolvers)).finish();
+
+    let mut notification_rx = spawn_notification_collector(socket);
+
+    service.call(create_initialize_request(1)).await.unwrap();
+    service
+        .call(create_initialized_notification())
+        .await
+        .unwrap();
+
+    let package_swift = r#"import PackageDescription
+let package = Package(
+    name: "App",
+    dependencies: [
+        .package(url: "https://github.example.com/team/internal-lib.git", from: "1.0.0"),
+    ]
+)
+"#;
+
+    service
+        .call(create_did_open_notification(
+            "file:///test/Package.swift",
+            package_swift,
+        ))
+        .await
+        .unwrap();
+
+    let notification =
+        wait_for_notification(&mut notification_rx, "textDocument/publishDiagnostics")
+            .await
+            .expect("Expected publishDiagnostics notification");
+    let params: PublishDiagnosticsParams =
+        serde_json::from_value(notification.params().unwrap().clone()).unwrap();
+    assert_eq!(params.diagnostics.len(), 1);
+    assert_eq!(
+        params.diagnostics[0].severity,
+        Some(DiagnosticSeverity::WARNING)
+    );
+    assert_eq!(
+        params.diagnostics[0].message,
+        "Update available: 1.0.0 -> 2.0.0"
+    );
+}

--- a/tests/helper/registry.rs
+++ b/tests/helper/registry.rs
@@ -13,6 +13,7 @@ use version_lsp::parser::deno_json::DenoJsonParser;
 use version_lsp::parser::github_actions::GitHubActionsParser;
 use version_lsp::parser::go_mod::GoModParser;
 use version_lsp::parser::package_json::PackageJsonParser;
+use version_lsp::parser::package_swift::PackageSwiftParser;
 use version_lsp::parser::pnpm_workspace::PnpmWorkspaceParser;
 use version_lsp::parser::pyproject_toml::PyprojectTomlParser;
 use version_lsp::parser::types::RegistryType;
@@ -22,6 +23,7 @@ use version_lsp::version::error::RegistryError;
 use version_lsp::version::matchers::{
     CratesVersionMatcher, DockerVersionMatcher, GitHubActionsMatcher, GoVersionMatcher,
     JsrVersionMatcher, NpmVersionMatcher, PnpmCatalogMatcher, PypiVersionMatcher,
+    SwiftPmVersionMatcher,
 };
 use version_lsp::version::registries::github::GitHubRegistry;
 use version_lsp::version::registry::Registry;
@@ -116,6 +118,11 @@ pub fn create_test_resolver(
             Arc::new(DockerVersionMatcher),
             Arc::new(mock_registry),
         ),
+        RegistryType::SwiftPm => PackageResolver::new(
+            Arc::new(PackageSwiftParser::new()),
+            Arc::new(SwiftPmVersionMatcher),
+            Arc::new(mock_registry),
+        ),
     }
 }
 
@@ -139,4 +146,24 @@ pub fn create_test_cache(
     }
 
     (temp_dir, Arc::new(cache))
+}
+
+/// Create a SwiftPm test resolver whose parser accepts the supplied private
+/// hosts in addition to `github.com`. Mirrors the production wiring in
+/// `lsp::resolver::create_resolvers` for SwiftPm + a non-default
+/// `registries.swiftPm.url`.
+#[allow(dead_code)]
+pub fn create_swift_pm_resolver_with_hosts<I, S>(
+    mock_registry: MockRegistry,
+    extra_hosts: I,
+) -> PackageResolver
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    PackageResolver::new(
+        Arc::new(PackageSwiftParser::with_allowed_hosts(extra_hosts)),
+        Arc::new(SwiftPmVersionMatcher),
+        Arc::new(mock_registry),
+    )
 }


### PR DESCRIPTION
- Add `Package.swift` parser using tree-sitter-swift; extracts `from:`, `exact:`, `.upToNextMajor(from:)`, `.upToNextMinor(from:)`, half-open (`A ..< B`), and closed (`A ... B`) range constraints; skips branch/revision pins
- Add `SwiftPmVersionMatcher` reusing caret semantics for bare versions and evaluating compound ranges produced by the parser
- Reuse `GitHubRegistry` for SPM version fetches; add `with_registry_type()` builder so the same HTTP backend can report `RegistryType::SwiftPm` keeping cache namespaces separate from GitHub Actions
- Add `RegistryType::SwiftPm` variant with `as_str` / `FromStr` round-trip and `detect_parser_type` routing for `Package.swift` URIs
- Wire `registries.swiftPm` config block (`enabled`, `url`) into `LspConfig`; `swiftPm.url` doubles as a GitHub Enterprise API base URL override and adds the URL's bare host to the parser's allow-list for private mirror support
- Register `PackageSwiftParser` in `create_resolvers`; expose `swift_pm_parser_from` and `swift_pm_registry_from` helpers
- Add E2E test file, resolver unit tests, `host_from_url` extraction tests, and test helper wiring for the new registry type
- Update README, CLAUDE.md, and ARCHITECTURE.md to document the new registry